### PR TITLE
Upgrades redis.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "redis": "0.8.x"
+    "redis": "~0.10.x"
   },
   "devDependencies": {
     "mocha": "1.9.x",


### PR DESCRIPTION
I don't think we should be so strict w/ version 0.8.x. Here's a big reason why we need the latest version of redis...

https://github.com/mranney/node_redis/commit/0b6870be5cab57315594fadd1fd205647b267932

If you are using redis in a before_perform plugin, and the callback fails, it won't be picked up by the worker's domain.
