### PR TITLE
Allows jobLock option.key to be a function.

### DIFF
--- a/lib/plugins/jobLock.js
+++ b/lib/plugins/jobLock.js
@@ -86,7 +86,7 @@ jobLock.prototype.enqueue_timeout = function(){
 jobLock.prototype.key = function(){
   var self = this;
   if (self.options.key != null){
-    return self.options.key;
+    return typeof self.options.key === 'function' ? self.options.key.apply(this) : self.options.key;
   }else{
     var flattenedArgs = JSON.stringify(self.args);
     return self.worker.connection.key('workerslock', self.func, self.queue, flattenedArgs);

--- a/lib/plugins/queueLock.js
+++ b/lib/plugins/queueLock.js
@@ -29,7 +29,7 @@ queueLock.prototype.before_enqueue = function(callback){
         redisTimeout = parseInt(redisTimeout);
         if(now <= redisTimeout){
           callback(null, false);
-        }else{  
+        }else{
           self.worker.connection.redis.set(key, timeout, function(err){
             self.worker.connection.redis.get(key, function(err, redisTimeout){
               redisTimeout = parseInt(redisTimeout);
@@ -81,7 +81,7 @@ queueLock.prototype.lock_timeout = function(){
 queueLock.prototype.key = function(){
   var self = this;
   if (self.options.key != null){
-    return self.options.key;
+    return typeof self.options.key === 'function' ? self.options.key.apply(this) : self.options.key;
   }else{
     var flattenedArgs = JSON.stringify(self.args);
     return self.worker.connection.key('lock', self.func, self.queue, flattenedArgs);


### PR DESCRIPTION
This can be used to return custom keys that depend on the job. My use
case is to prevent multiple jobs of the same type from running, and
ignoring their options.
