### PR TITLE
Change config syntax to allow passing of redis client package name

### DIFF
--- a/examples/customPluginExample.js
+++ b/examples/customPluginExample.js
@@ -10,6 +10,7 @@ var NR = require(__dirname + "/../index.js");
 ///////////////////////////
 
 var connectionDetails = {
+  package:   "redis",
   host:      "127.0.0.1",
   password:  "",
   port:      6379,

--- a/examples/errorExample.js
+++ b/examples/errorExample.js
@@ -10,6 +10,7 @@ var NR = require(__dirname + "/../index.js");
 ///////////////////////////
 
 var connectionDetails = {
+  package:   "redis",
   host:      "127.0.0.1",
   password:  "",
   port:      6379,

--- a/examples/example.js
+++ b/examples/example.js
@@ -10,6 +10,7 @@ var NR = require(__dirname + "/../index.js");
 ///////////////////////////
 
 var connectionDetails = {
+  package:   "redis",
   host:      "127.0.0.1",
   password:  "",
   port:      6379,

--- a/examples/simpleWorker.js
+++ b/examples/simpleWorker.js
@@ -10,6 +10,7 @@ var NR = require(__dirname + "/../index.js");
 ///////////////////////////
 
 var connectionDetails = {
+  package:   "redis",
   host:      "127.0.0.1",
   password:  "",
   port:      6379,

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -22,7 +22,7 @@ var connection = function(options){
 
 connection.prototype.defaults = function(){
   return {
-    package:   require("redis"),
+    package:   "redis",
     host:      "127.0.0.1",
     password:  "",
     port:      6379,
@@ -33,7 +33,7 @@ connection.prototype.defaults = function(){
 
 connection.prototype.ensureConnected = function(parentCallback, callack){
   var self = this;
-  if(self.options.fake === true){
+  if(self.options.package === 'fakeredis'){
     callack();
   }else if(self.connected === false){
     var err = new Error('not connected to redis');
@@ -50,7 +50,8 @@ connection.prototype.ensureConnected = function(parentCallback, callack){
 connection.prototype.connect = function(callback){
   var self = this;
   var options = self.options;
-  self.redis = options.redis || options.package.createClient(options.port, options.host, options.options);
+  var package = require(self.options.package)
+  self.redis = options.redis || package.createClient(options.port, options.host, options.options);
   
   self.redis.on('error', function(err){
     // catch to prevent bubble up of error
@@ -68,7 +69,7 @@ connection.prototype.connect = function(callback){
         callback(err);
       });
     });
-  }else if(options.fake != true){
+  }else if(self.options.package != 'fakeredis'){
     self.redis.select(options.database, function(err){
       self.redis.info(function(err, data){
         callback(err); 

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@ The configuration hash passed to `new worker`, `new scheduler` or `new queue` ca
 
 ```javascript
 var connectionDetails = {
+  package:   "redis",
   host:      "127.0.0.1",
   password:  "",
   port:      6379,

--- a/test/_specHelper.js
+++ b/test/_specHelper.js
@@ -3,17 +3,17 @@ var fakeredis = require('fakeredis');
 var namespace = "resque_test";
 var queue = "test_queue";
 
-var toFakeredis = true;
-if(process.env.fakeredis == 'false'){ toFakeredis = false;  }
+var package = 'redis';
+if(process.env.fakeredis == 'true'){ package = 'fakeredis';  }
 
 exports.specHelper = {
-  toFakeredis: toFakeredis,
+  package: package,
   NR: require(__dirname + "/../index.js"),
   namespace: namespace,
   queue: queue,
   timeout: 500,
   connectionDetails: {
-    fake:      toFakeredis, 
+    package:   package, 
     host:      "127.0.0.1",
     password:  "",
     port:      6379,
@@ -23,7 +23,7 @@ exports.specHelper = {
   },
   connect: function(callback){
     var self = this;
-    if(toFakeredis != true){
+    if(package != 'fakeredis'){
       self.redis = redis.createClient(self.connectionDetails.port, self.connectionDetails.host, self.connectionDetails.options);
       if(self.connectionDetails.password != null && self.connectionDetails.password != ""){
         self.redis.auth(self.connectionDetails.password, function(err){


### PR DESCRIPTION
This PR allows you to provide the package name of the resque client package you wish to use as part of the connection config hash.  

Previously, you could only use `redis` or `fakeredis`, but there are many more clients you may want to try (like [redis-sentinel-client](https://github.com/DocuSignDev/node-redis-sentinel-client))
