### PR TITLE
Callback undefined on subsequent poll() calls

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -115,7 +115,7 @@ worker.prototype.poll = function(nQueue, callback) {
             });
           }else{
             process.nextTick(function(){
-              self.poll(nQueue + 1);
+              self.poll(nQueue + 1, callback);
             });
           }
         }


### PR DESCRIPTION
If the worker is running in non-looped mode (for testing in my case) the
callback is undefined on the first `poll()` recursion.  This means that
if a job is found (or all queues have been polled) the callback
originally passed to poll is lost.
