### PR TITLE
allow defining jobs with function only

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,7 +16,7 @@ var worker = function(options, jobs, callback){
     }
   }
   self.options = options;
-  self.jobs = jobs;
+  self.jobs = prepareJobs(jobs);
   self.name = self.options.name;
   self.queues = self.options.queues;
   self.error = null;
@@ -365,6 +365,14 @@ worker.prototype.stringQueues = function(){
   }else{
     return self.queues.join(',');
   }
+}
+
+function prepareJobs(jobs) {
+  return Object.keys(jobs).reduce(function(h, k) {
+    var job = jobs[k];
+    h[k] = typeof job === 'function' ? { perform: job } : job;
+    return h;
+  }, {});
 }
 
 exports.worker = worker;

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,9 @@ var jobs = {
       callback(null, answer);
     },
   },
+  "multiply": function(a,b,callback) {
+    callback(null, a * b);
+  },
 };
 
 ////////////////////

--- a/test/core/worker.js
+++ b/test/core/worker.js
@@ -25,7 +25,10 @@ describe('worker', function(){
         setTimeout(function(){ callback(null, 'b'); }, 500);
         setTimeout(function(){ callback(null, 'c'); }, 1000);
       }
-    }
+    },
+    "quickDefine": function(callback) {
+      setTimeout(callback.bind(null, null, "ok"));
+    },
   };
 
   it("can connect", function(done){
@@ -151,6 +154,19 @@ describe('worker', function(){
         queue.enqueue(specHelper.queue, "add", [1,2]);
         worker.start();
       });
+
+      it('can accept jobs that are simple functions', function(done){
+        var listener = worker.on('success', function(q, job, result){
+          result.should.equal("ok");
+
+          worker.removeAllListeners('success');
+          done();
+        });
+
+        queue.enqueue(specHelper.queue, "quickDefine", []);
+        worker.start();
+      });
+
 
       it('will not work jobs that are not defined', function(done){
         var listener = worker.on('failure', function(q, job, failure){


### PR DESCRIPTION
- function only definition
- transform 'sugar' API from outside into original job definition format
