### PR TITLE
Types Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ async function boot() {
   scheduler.on("poll", () => {
     console.log("scheduler polling");
   });
-  scheduler.on("master", state => {
+  scheduler.on("master", () => {
     console.log("scheduler became master");
   });
   scheduler.on("error", error => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -129,7 +129,7 @@ async function boot() {
   scheduler.on("poll", () => {
     console.log("scheduler polling");
   });
-  scheduler.on("master", state => {
+  scheduler.on("master", () => {
     console.log("scheduler became master");
   });
   scheduler.on("error", error => {

--- a/examples/multiWorker.ts
+++ b/examples/multiWorker.ts
@@ -139,9 +139,6 @@ async function boot() {
   });
 
   // multiWorker emitters
-  multiWorker.on("internalError", error => {
-    console.log(error);
-  });
   multiWorker.on("multiWorkerAction", (verb, delay) => {
     console.log(
       `*** checked for worker status: ${verb} (event loop delay: ${delay}ms)`

--- a/examples/retry.ts
+++ b/examples/retry.ts
@@ -107,7 +107,7 @@ async function boot() {
   scheduler.on("poll", () => {
     console.log("scheduler polling");
   });
-  scheduler.on("master", state => {
+  scheduler.on("master", () => {
     console.log("scheduler became master");
   });
   scheduler.on("error", error => {

--- a/examples/scheduledJobs.ts
+++ b/examples/scheduledJobs.ts
@@ -95,7 +95,7 @@ async function boot() {
   scheduler.on("poll", () => {
     console.log("scheduler polling");
   });
-  scheduler.on("master", state => {
+  scheduler.on("master", () => {
     console.log("scheduler became master");
   });
   scheduler.on("error", error => {

--- a/examples/stuckWorker.ts
+++ b/examples/stuckWorker.ts
@@ -103,7 +103,7 @@ async function boot() {
   scheduler.on("poll", () => {
     console.log("scheduler polling");
   });
-  scheduler.on("master", state => {
+  scheduler.on("master", () => {
     console.log("scheduler became master");
   });
   scheduler.on("error", error => {

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -14,12 +14,8 @@ export class Connection extends EventEmitter {
   connected: boolean;
   redis: IORedis.Redis;
 
-  constructor(options) {
+  constructor(options: ConnectionOptions = {}) {
     super();
-
-    if (!options) {
-      options = {};
-    }
 
     const defaults = {
       pkg: "ioredis",

--- a/src/core/multiWorker.ts
+++ b/src/core/multiWorker.ts
@@ -5,113 +5,57 @@ import { Connection } from "./connection";
 import { EventLoopDelay } from "./../utils/eventLoopDelay";
 import { MultiWorkerOptions } from "../types/options";
 import { Jobs } from "../types/jobs";
+import { Job } from "../types/Job";
 
-/**
- * ## Events
- * ```js
- * // worker-class emitters
- * multiWorker.on("start", workerId => {
- *   console.log("worker[" + workerId + "] started");
- * });
- * multiWorker.on("end", workerId => {
- *   console.log("worker[" + workerId + "] ended");
- * });
- * multiWorker.on("cleaning_worker", (workerId, worker, pid) => {
- *   console.log("cleaning old worker " + worker);
- * });
- * multiWorker.on("poll", (workerId, queue) => {
- *   console.log("worker[" + workerId + "] polling " + queue);
- * });
- * multiWorker.on("ping", (workerId, time) => {
- *   console.log("worker[" + workerId + "] check in @ " + time);
- * });
- * multiWorker.on("job", (workerId, queue, job) => {
- *   console.log(
- *     "worker[" + workerId + "] working job " + queue + " " + JSON.stringify(job)
- *   );
- * });
- * multiWorker.on("reEnqueue", (workerId, queue, job, plugin) => {
- *   console.log(
- *     "worker[" +
- *       workerId +
- *       "] reEnqueue job (" +
- *       plugin +
- *       ") " +
- *       queue +
- *       " " +
- *       JSON.stringify(job)
- *   );
- * });
- * multiWorker.on("success", (workerId, queue, job, result) => {
- *   console.log(
- *     "worker[" +
- *       workerId +
- *       "] job success " +
- *       queue +
- *       " " +
- *       JSON.stringify(job) +
- *       " >> " +
- *       result
- *   );
- * });
- * multiWorker.on("failure", (workerId, queue, job, failure) => {
- *   console.log(
- *     "worker[" +
- *       workerId +
- *       "] job failure " +
- *       queue +
- *       " " +
- *       JSON.stringify(job) +
- *       " >> " +
- *       failure
- *   );
- * });
- * multiWorker.on("error", (workerId, queue, job, error) => {
- *   console.log(
- *     "worker[" +
- *       workerId +
- *       "] error " +
- *       queue +
- *       " " +
- *       JSON.stringify(job) +
- *       " >> " +
- *       error
- *   );
- * });
- * multiWorker.on("pause", workerId => {
- *   console.log("worker[" + workerId + "] paused");
- * });
- * ```
- * ```js
- * // multiWorker-specfic emitters
- * multiWorker.on("internalError", error => {
- *   console.log(error);
- * });
- * multiWorker.on("multiWorkerAction", (verb, delay) => {
- *   console.log(
- *     "*** checked for worker status: " +
- *       verb +
- *       " (event loop delay: " +
- *       delay +
- *       "ms)"
- *   );
- * });
- * ```
- */
-export class MultiWorker extends EventEmitter {
+export declare interface MultiWorker {
   options: MultiWorkerOptions;
   jobs: Jobs;
   workers: Array<Worker>;
   name: string;
   running: boolean;
   working: boolean;
-  private eventLoopBlocked: boolean;
-  private eventLoopDelay: number;
-  private eventLoopCheckCounter: number;
-  private stopInProcess: boolean;
+  eventLoopBlocked: boolean;
+  eventLoopDelay: number;
+  eventLoopCheckCounter: number;
+  stopInProcess: boolean;
   connection: Connection;
   checkTimer: NodeJS.Timeout;
 
+  on(event: "start" | "end", cb: (workerId: number) => void): this;
+  on(
+    event: "cleaning_worker",
+    cb: (workerId: number, worker: Worker, pid: number) => void
+  ): this;
+  on(event: "poll", cb: (workerId: number, queue: string) => void): this;
+  on(event: "ping", cb: (workerId: number, time: number) => void): this;
+  on(
+    event: "job",
+    cb: (workerId: number, queue: string, job: Job<any>) => void
+  ): this;
+  on(
+    event: "reEnqueue",
+    cb: (workerId: number, queue: string, job: Job<any>, plugin: string) => void
+  ): this;
+  on(
+    event: "success",
+    cb: (workerId: number, queue: string, job: Job<any>, result: any) => void
+  ): this;
+  on(
+    event: "failure",
+    cb: (workerId: number, queue: string, job: Job<any>, failure: any) => void
+  ): this;
+  on(
+    event: "error",
+    cb: (workerId: number, queue: string, job: Job<any>, error: any) => void
+  ): this;
+  on(event: "pause", cb: (workerId: number) => void): this;
+  on(
+    event: "multiWorkerAction",
+    cb: (verb: string, delay: number) => void
+  ): this;
+}
+
+export class MultiWorker extends EventEmitter {
   constructor(options, jobs) {
     super();
 

--- a/src/core/multiWorker.ts
+++ b/src/core/multiWorker.ts
@@ -5,7 +5,7 @@ import { Connection } from "./connection";
 import { EventLoopDelay } from "./../utils/eventLoopDelay";
 import { MultiWorkerOptions } from "../types/options";
 import { Jobs } from "../types/jobs";
-import { Job } from "../types/Job";
+import { Job } from "../types/job";
 
 export declare interface MultiWorker {
   options: MultiWorkerOptions;

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -14,11 +14,15 @@ function arrayify(o) {
   }
 }
 
-export class Queue extends EventEmitter {
+export declare interface Queue {
   connection: Connection;
   options: ConnectionOptions;
   jobs: Jobs;
 
+  on(event: "error", cb: (error: Error, queue: string) => void): this;
+  once(event: "error", cb: (error: Error, queue: string) => void): this;
+}
+export class Queue extends EventEmitter {
   constructor(options, jobs = {}) {
     super();
 

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -6,7 +6,7 @@ import * as os from "os";
 import { Queue } from "./queue";
 import { Connection } from "./connection";
 import { SchedulerOptions } from "../types/options";
-import { Job } from "../types/Job";
+import { Job } from "../types/job";
 import { Jobs } from "../types/jobs";
 import { ErrorPayload } from "../types/errorPayload";
 

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -6,50 +6,59 @@ import * as os from "os";
 import { Queue } from "./queue";
 import { Connection } from "./connection";
 import { SchedulerOptions } from "../types/options";
+import { Job } from "../types/Job";
 import { Jobs } from "../types/jobs";
+import { ErrorPayload } from "../types/errorPayload";
 
-/**
- * ## Events
- * ```
- * scheduler.on("start", () => {
- *   console.log("scheduler started");
- * });
- * scheduler.on("end", () => {
- *   console.log("scheduler ended");
- * });
- *  scheduler.on("poll", () => {
- *    console.log("scheduler polling");
- *  });
- *  scheduler.on("master", state => {
- *    console.log("scheduler became master");
- *  });
- *  scheduler.on("error", error => {
- *    console.log(`scheduler error >> ${error}`);
- *  });
- *  scheduler.on("cleanStuckWorker", (workerName, errorPayload, delta) => {
- *    console.log(
- *      `failing ${workerName} (stuck for ${delta}s) and failing job ${errorPayload}`
- *    );
- *  });
- *  scheduler.on("workingTimestamp", timestamp => {
- *    console.log(`scheduler working timestamp ${timestamp}`);
- *  });
- *  scheduler.on("transferredJob", (timestamp, job) => {
- *    console.log(`scheduler enquing job ${timestamp} >> ${JSON.stringify(job)}`);
- *  });
- * ```
- */
-export class Scheduler extends EventEmitter {
+export declare interface Scheduler {
   options: SchedulerOptions;
   jobs: Jobs;
   name: string;
   master: boolean;
   running: boolean;
-  private processing: boolean;
+  processing: boolean;
   queue: Queue;
   connection: Connection;
-  private timer: NodeJS.Timeout;
+  timer: NodeJS.Timeout;
 
+  on(event: "start" | "end" | "poll" | "master", cb: () => void): this;
+  on(
+    event: "cleanStuckWorker",
+    cb: (workerName: string, errorPayload: ErrorPayload, delta: number) => void
+  ): this;
+  on(event: "error", cb: (error: Error, queue: string) => void): this;
+  on(event: "workingTimestamp", cb: (timestamp: number) => void): this;
+  on(
+    event: "transferredJob",
+    cb: (timestamp: number, job: Job<any>) => void
+  ): this;
+
+  once(event: "start" | "end" | "poll" | "master", cb: () => void): this;
+  once(
+    event: "cleanStuckWorker",
+    cb: (workerName: string, errorPayload: ErrorPayload, delta: number) => void
+  ): this;
+  once(event: "error", cb: (error: Error, queue: string) => void): this;
+  once(event: "workingTimestamp", cb: (timestamp: number) => void): this;
+  once(
+    event: "transferredJob",
+    cb: (timestamp: number, job: Job<any>) => void
+  ): this;
+
+  removeAllListeners(event: SchedulerEvent): this;
+}
+
+export type SchedulerEvent =
+  | "start"
+  | "end"
+  | "poll"
+  | "master"
+  | "cleanStuckWorker"
+  | "error"
+  | "workingTimestamp"
+  | "transferredJob";
+
+export class Scheduler extends EventEmitter {
   constructor(options, jobs = {}) {
     super();
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -35,7 +35,7 @@ export declare interface Worker {
   id: number;
 
   on(event: "start" | "end" | "pause", cb: () => void): this;
-  on(event: "cleaning_worker", cb: (worker: string, pid: string) => void): this;
+  on(event: "cleaning_worker", cb: (worker: Worker, pid: string) => void): this;
   on(event: "poll", cb: (queue: string) => void): this;
   on(event: "ping", cb: (time: number) => void): this;
   on(event: "job", cb: (queue: string, job: Job<any>) => void): this;
@@ -59,7 +59,7 @@ export declare interface Worker {
   once(event: "start" | "end" | "pause", cb: () => void): this;
   once(
     event: "cleaning_worker",
-    cb: (worker: string, pid: string) => void
+    cb: (worker: Worker, pid: string) => void
   ): this;
   once(event: "poll", cb: (queue: string) => void): this;
   once(event: "ping", cb: (time: number) => void): this;

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -15,63 +15,89 @@ function prepareJobs(jobs) {
   }, {});
 }
 
-/**
- * ## Events
- * ```
- * worker.on("start", () => {
- *   console.log("worker started");
- * });
- * worker.on("end", () => {
- *   console.log("worker ended");
- * });
- * worker.on("cleaning_worker", (worker, pid) => {
- *   console.log(`cleaning old worker ${worker}`);
- * });
- * worker.on("poll", queue => {
- *   console.log(`worker polling ${queue}`);
- * });
- * worker.on("ping", time => {
- *   console.log(`worker check in @ ${time}`);
- * });
- * worker.on("job", (queue, job) => {
- *   console.log(`working job ${queue} ${JSON.stringify(job)}`);
- * });
- * worker.on("reEnqueue", (queue, job, plugin) => {
- *   console.log(`reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`);
- * });
- * worker.on("success", (queue, job, result) => {
- *  console.log(`job success ${queue} ${JSON.stringify(job)} >> ${result}`);
- * });
- * worker.on("failure", (queue, job, failure) => {
- *   console.log(`job failure ${queue} ${JSON.stringify(job)} >> ${failure}`);
- * });
- * worker.on("error", (error, queue, job) => {
- *   console.log(`error ${queue} ${JSON.stringify(job)}  >> ${error}`);
- * });
- * worker.on("pause", () => {
- *   console.log("worker paused");
- * });
- * ```
- */
-export class Worker extends EventEmitter {
+export declare interface Worker {
   options: WorkerOptions;
   jobs: Jobs;
   started: boolean;
   name: string;
   queues: Array<string>;
   queue: string;
-  private originalQueue: string | null;
+  originalQueue: string | null;
   error: Error | null;
   result: any;
   ready: boolean;
   running: boolean;
   working: boolean;
-  private pingTimer: NodeJS.Timeout;
+  pingTimer: NodeJS.Timeout;
   job: Job<any>;
   connection: Connection;
   queueObject: Queue;
   id: number;
 
+  on(event: "start" | "end" | "pause", cb: () => void): this;
+  on(event: "cleaning_worker", cb: (worker: string, pid: string) => void): this;
+  on(event: "poll", cb: (queue: string) => void): this;
+  on(event: "ping", cb: (time: number) => void): this;
+  on(event: "job", cb: (queue: string, job: Job<any>) => void): this;
+  on(
+    event: "reEnqueue",
+    cb: (queue: string, job: Job<any>, plugin: string) => void
+  ): this;
+  on(
+    event: "success",
+    cb: (queue: string, job: Job<any>, result: any) => void
+  ): this;
+  on(
+    event: "failure",
+    cb: (queue: string, job: Job<any>, failure: any) => void
+  ): this;
+  on(
+    event: "error",
+    cb: (error: Error, queue: string, job: Job<any>) => void
+  ): this;
+
+  once(event: "start" | "end" | "pause", cb: () => void): this;
+  once(
+    event: "cleaning_worker",
+    cb: (worker: string, pid: string) => void
+  ): this;
+  once(event: "poll", cb: (queue: string) => void): this;
+  once(event: "ping", cb: (time: number) => void): this;
+  once(event: "job", cb: (queue: string, job: Job<any>) => void): this;
+  once(
+    event: "reEnqueue",
+    cb: (queue: string, job: Job<any>, plugin: string) => void
+  ): this;
+  once(
+    event: "success",
+    cb: (queue: string, job: Job<any>, result: any) => void
+  ): this;
+  once(
+    event: "failure",
+    cb: (queue: string, job: Job<any>, failure: any) => void
+  ): this;
+  once(
+    event: "error",
+    cb: (error: Error, queue: string, job: Job<any>) => void
+  ): this;
+
+  removeAllListeners(event: WorkerEvent): this;
+}
+
+export type WorkerEvent =
+  | "start"
+  | "end"
+  | "cleaning_worker"
+  | "poll"
+  | "ping"
+  | "job"
+  | "reEnqueue"
+  | "success"
+  | "failure"
+  | "error"
+  | "pause";
+
+export class Worker extends EventEmitter {
   constructor(options, jobs = {}) {
     super();
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -67,7 +67,7 @@ export class Worker extends EventEmitter {
   running: boolean;
   working: boolean;
   private pingTimer: NodeJS.Timeout;
-  job: Job;
+  job: Job<any>;
   connection: Connection;
   queueObject: Queue;
   id: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ export { Plugin } from "./core/plugin";
 
 export { ConnectionOptions } from "./types/options";
 export { Job } from "./types/job";
-export { Jobs } from "./types/Jobs";
+export { Jobs } from "./types/jobs";
 export { ErrorPayload } from "./types/errorPayload";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,6 @@ export { MultiWorker } from "./core/multiWorker";
 export { Plugin } from "./core/plugin";
 
 export { ConnectionOptions } from "./types/options";
-export { Job } from "./types/Job";
+export { Job } from "./types/job";
 export { Jobs } from "./types/Jobs";
 export { ErrorPayload } from "./types/errorPayload";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,11 @@
-/**
- * I export the following classes: Connection, Queue, Scheduler, Worker, MultiWorker, Plugin
- *
- * ```typescript
- * import { Connection, Queue, Scheduler, Worker, MultiWorker, Plugin } from 'node-resque'
- * ```
- */
-
 export { Connection } from "./core/connection";
 export { Queue } from "./core/queue";
 export { Scheduler } from "./core/scheduler";
 export { Worker } from "./core/worker";
 export { MultiWorker } from "./core/multiWorker";
 export { Plugin } from "./core/plugin";
+
+export { ConnectionOptions } from "./types/options";
+export { Job } from "./types/Job";
+export { Jobs } from "./types/Jobs";
+export { ErrorPayload } from "./types/errorPayload";

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,9 +1,9 @@
-export interface Job {
-  plugins: Array<any> | null;
+export interface Job<TResult> {
+  plugins: Array<any>;
   pluginOptions: {
-    [key: string]: {
+    [pluginName: string]: {
       [key: string]: any;
     };
   };
-  perform: Function;
+  perform: (...args: any[]) => Promise<TResult>;
 }

--- a/src/types/jobs.ts
+++ b/src/types/jobs.ts
@@ -1,5 +1,5 @@
 import { Job } from "./job";
 
 export interface Jobs {
-  [key: string]: Job;
+  [jobName: string]: Job<any>;
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -3,37 +3,43 @@ import * as IORedis from "ioredis";
 import { Connection } from "../core/connection";
 
 export interface ConnectionOptions {
-  options: ConnectionOptions;
-  pkg: string;
-  db: number;
-  database: number;
-  host: string;
-  port: number;
-  namespace: string;
-  redis?: IORedis.Redis | null;
+  pkg?: string;
+  host?: string;
+  port?: number;
+  database?: number;
+  namespace?: string;
+  looping?: boolean;
+  options?: any;
+  redis?: IORedis.Redis;
 }
 
 export interface WorkerOptions extends ConnectionOptions {
-  name?: string | null;
-  queues?: Array<string> | null;
-  timeout?: number | null;
-  looping?: boolean | null;
+  name?: string;
+  queues?: Array<string>;
+  timeout?: number;
+  looping?: boolean;
 }
 
 export interface SchedulerOptions extends ConnectionOptions {
-  name?: string | null;
-  timeout?: number | null;
-  masterLockTimeout: number | null;
-  stuckWorkerTimeout: number | null;
+  name?: string;
+  timeout?: number;
+  masterLockTimeout: number;
+  stuckWorkerTimeout: number;
 }
 
 export interface MultiWorkerOptions extends ConnectionOptions {
-  name?: string | null;
-  queues?: Array<string> | null;
-  timeout?: number | null;
-  maxEventLoopDelay: number | null;
-  checkTimeout: number | null;
-  connection: Connection | null;
-  minTaskProcessors: number | null;
-  maxTaskProcessors: number | null;
+  name?: string;
+  queues?: Array<string>;
+  timeout?: number;
+  maxEventLoopDelay?: number;
+  checkTimeout?: number;
+  connection?: Connection;
+  minTaskProcessors?: number;
+  maxTaskProcessors?: number;
+}
+
+export interface Job<TResult> {
+  plugins?: string[];
+  pluginOptions?: { [pluginName: string]: any };
+  perform: (...args: any[]) => Promise<TResult>;
 }


### PR DESCRIPTION
* Export Job, ConnectionOptions, and ErrorPayload
* Include event types for Worker, Scheduler, Queue, and Multiworker

Thanks to https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node-resque/index.d.ts for lots of hints

It is interesting to note that in Typescript, you must define the events in an abstraction (interface) and not directly on the class.  That is why each of our classes now have a `declare interface Scheduler` and a `class Scheduler extends EventEmitter`.  Typescript knows how to merge them both on export