### PR TITLE
Move types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   },
   "dependencies": {
     "@types/ioredis": "^4.0.19",
-    "@types/jest": "^24.0.23",
     "@types/node": "^12.12.7",
     "ioredis": "^4.14.1"
   },
   "devDependencies": {
+    "@types/jest": "^24.0.23",
     "jest": "^24.9.0",
     "node-schedule": "^1.3.2",
     "prettier": "^1.19.1",


### PR DESCRIPTION
### What
```
npm i @types/jest@24.0.23 --save-dev
npm notice save @types/jest is being moved from dependencies to devDependencies
```

It's better not to pack types with your package while publishing.
Types considered to be dev dependencies since you use them for compile your code.
But consumers of your library don't need them.

**Ideally** I would also move `@types/ioredis` and `@types/node` to dev dependencies.

### Why

So I tried to switch my project to `node-resque@6.0.5` and I got conflicts.
This is because I use `mocha` but you use `jest` framework.
And they now have conflicts because of same names in global namespace.
See the screenshot below.

<img width="1227" alt="Screenshot 2019-12-13 at 13 16 44" src="https://user-images.githubusercontent.com/2134746/70773857-2bd1bc00-1dab-11ea-865d-6f29e486850d.png">
