### PR TITLE
Use `multi` transactions to increase safety with delayed jobs

### DIFF
--- a/__tests__/core/worker.ts
+++ b/__tests__/core/worker.ts
@@ -212,7 +212,7 @@ describe("worker", () => {
         });
       });
 
-      // TODO: Typescript seems to have troble with frozen objects
+      // TODO: Typescript seems to have trouble with frozen objects
       // test('job arguments are immutable', async (done) => {
       //   await queue.enqueue(specHelper.queue, 'messWithData', { a: 'starting value' })
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "node-resque",
   "description": "an opinionated implementation of resque in node",
   "license": "Apache-2.0",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "homepage": "http://github.com/actionhero/node-resque",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR uses Redis transactions (with multi) when enqueuing a delayed job and deleting a delayed job queue.

We need to invoke the "watch" command by the scheduler to be notified of any changes to the delayed queue we are about to delete.  Then we check that its length is 0.  If it isn't we exit.  If it is, we start preparing the new multi() command to delete the queue and its entry in `delayed_queue_schedule`.  If a new job is inserted while we are doing this, the "watch" command will prevent the delete from succeeding. 

Otherwise, even in the race condition when a job is being added to the same delayed queue that is being removed, the scheduler will remove the queue and entry in `delayed_queue_schedule`, and then the enqueue will add it back again.