### PR TITLE
Emit Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,17 @@ async function boot() {
   worker.on("reEnqueue", (queue, job, plugin) => {
     console.log(`reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`);
   });
-  worker.on("success", (queue, job, result) => {
-    console.log(`job success ${queue} ${JSON.stringify(job)} >> ${result}`);
+  worker.on("success", (queue, job, result, duration) => {
+    console.log(
+      `job success ${queue} ${JSON.stringify(job)} >> ${result} (${duration}ms)`
+    );
   });
-  worker.on("failure", (queue, job, failure) => {
-    console.log(`job failure ${queue} ${JSON.stringify(job)} >> ${failure}`);
+  worker.on("failure", (queue, job, failure, duration) => {
+    console.log(
+      `job failure ${queue} ${JSON.stringify(
+        job
+      )} >> ${failure} (${duration}ms)`
+    );
   });
   worker.on("error", (error, queue, job) => {
     console.log(`error ${queue} ${JSON.stringify(job)}  >> ${error}`);

--- a/__tests__/core/multiWorker.ts
+++ b/__tests__/core/multiWorker.ts
@@ -135,14 +135,18 @@ describe("multiWorker", () => {
     await new Promise((resolve, reject) => {
       multiWorker.start();
 
-      multiWorker.on("failure", async (workerId, queue, job, error) => {
-        expect(String(error)).toBe(
-          'Error: No job defined for class "missingJob"'
-        );
-        multiWorker.removeAllListeners("error");
-        await multiWorker.end();
-        resolve();
-      });
+      multiWorker.on(
+        "failure",
+        async (workerId, queue, job, error, duration) => {
+          expect(String(error)).toBe(
+            'Error: No job defined for class "missingJob"'
+          );
+          expect(duration).toBeGreaterThanOrEqual(0);
+          multiWorker.removeAllListeners("error");
+          await multiWorker.end();
+          resolve();
+        }
+      );
     });
   });
 });

--- a/__tests__/core/worker.ts
+++ b/__tests__/core/worker.ts
@@ -196,16 +196,17 @@ describe("worker", () => {
         });
       });
 
-      test("can work a job and return succesful things", async done => {
+      test("can work a job and return successful things", async done => {
         await queue.enqueue(specHelper.queue, "add", [1, 2]);
 
         worker.start();
 
-        worker.on("success", (q, job, result) => {
+        worker.on("success", (q, job, result, duration) => {
           expect(q).toBe(specHelper.queue);
           expect(job.class).toBe("add");
           expect(result).toBe(3);
           expect(worker.result).toBe(result);
+          expect(duration).toBeGreaterThanOrEqual(0);
 
           worker.removeAllListeners("success");
           done();
@@ -232,8 +233,9 @@ describe("worker", () => {
 
         worker.start();
 
-        worker.on("success", (q, job, result) => {
+        worker.on("success", (q, job, result, duration) => {
           expect(result).toBe("ok");
+          expect(duration).toBeGreaterThanOrEqual(0);
           worker.removeAllListeners("success");
           done();
         });

--- a/__tests__/core/worker.ts
+++ b/__tests__/core/worker.ts
@@ -246,11 +246,12 @@ describe("worker", () => {
 
         worker.start();
 
-        worker.on("failure", (q, job, failure) => {
+        worker.on("failure", (q, job, failure, duration) => {
           expect(q).toBe(specHelper.queue);
           expect(String(failure)).toBe(
             'Error: No job defined for class "somethingFake"'
           );
+          expect(duration).toBeGreaterThanOrEqual(0);
 
           worker.removeAllListeners("failure");
           done();

--- a/examples/customPluginExample.ts
+++ b/examples/customPluginExample.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Plugin, Worker, Queue } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 

--- a/examples/errorExample.ts
+++ b/examples/errorExample.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Queue, Worker } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Worker, Scheduler, Queue } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 
@@ -107,11 +109,17 @@ async function boot() {
   worker.on("reEnqueue", (queue, job, plugin) => {
     console.log(`reEnqueue job (${plugin}) ${queue} ${JSON.stringify(job)}`);
   });
-  worker.on("success", (queue, job, result) => {
-    console.log(`job success ${queue} ${JSON.stringify(job)} >> ${result}`);
+  worker.on("success", (queue, job, result, duration) => {
+    console.log(
+      `job success ${queue} ${JSON.stringify(job)} >> ${result} (${duration}ms)`
+    );
   });
-  worker.on("failure", (queue, job, failure) => {
-    console.log(`job failure ${queue} ${JSON.stringify(job)} >> ${failure}`);
+  worker.on("failure", (queue, job, failure, duration) => {
+    console.log(
+      `job failure ${queue} ${JSON.stringify(
+        job
+      )} >> ${failure} (${duration}ms)`
+    );
   });
   worker.on("error", (error, queue, job) => {
     console.log(`error ${queue} ${JSON.stringify(job)}  >> ${error}`);

--- a/examples/multiWorker.ts
+++ b/examples/multiWorker.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { MultiWorker, Queue } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 
@@ -115,18 +117,18 @@ async function boot() {
       )}`
     );
   });
-  multiWorker.on("success", (workerId, queue, job, result) => {
+  multiWorker.on("success", (workerId, queue, job, result, duration) => {
     console.log(
       `worker[${workerId}] job success ${queue} ${JSON.stringify(
         job
-      )} >> ${result}`
+      )} >> ${result} (${duration}ms)`
     );
   });
-  multiWorker.on("failure", (workerId, queue, job, failure) => {
+  multiWorker.on("failure", (workerId, queue, job, failure, duration) => {
     console.log(
       `worker[${workerId}] job failure ${queue} ${JSON.stringify(
         job
-      )} >> ${failure}`
+      )} >> ${failure} (${duration}ms)`
     );
   });
   multiWorker.on("error", (error, workerId, queue, job) => {

--- a/examples/performInline.ts
+++ b/examples/performInline.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Worker } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 

--- a/examples/retry.ts
+++ b/examples/retry.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Worker, Scheduler, Queue } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 

--- a/examples/scheduledJobs.ts
+++ b/examples/scheduledJobs.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Scheduler, Queue, Worker } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 

--- a/examples/stuckWorker.ts
+++ b/examples/stuckWorker.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import { Queue, Scheduler, Worker } from "./../src/index";
 // In your projects: import { Worker, Scheduler, Queue } from "node-resque";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-resque",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     }
   },
   "scripts": {
-    "prepare": "npm run declaration && npm run docs",
+    "prepare": "npm run build && npm run docs",
     "pretest": "npm run lint",
     "lint": "prettier --check src/*/**.ts __test__/*/**.ts examples/*/**.ts",
     "pretty": "prettier --write src/*/**.ts __test__/*/**.ts examples/*/**.ts",
     "test": "jest",
-    "declaration": "tsc --declaration",
+    "build": "tsc --declaration",
     "docs": "typedoc --out docs --theme default"
   }
 }

--- a/src/core/multiWorker.ts
+++ b/src/core/multiWorker.ts
@@ -47,7 +47,8 @@ export declare interface MultiWorker {
       workerId: number,
       queue: string,
       job: Job<any> | JobEmit,
-      result: any
+      result: any,
+      duration: number
     ) => void
   ): this;
   on(
@@ -56,7 +57,8 @@ export declare interface MultiWorker {
       workerId: number,
       queue: string,
       job: Job<any> | JobEmit,
-      failure: any
+      failure: any,
+      duration: number
     ) => void
   ): this;
   on(
@@ -167,11 +169,11 @@ export class MultiWorker extends EventEmitter {
     worker.on("reEnqueue", (queue, job, plugin) => {
       this.emit("reEnqueue", worker.id, queue, job, plugin);
     });
-    worker.on("success", (queue, job, result) => {
-      this.emit("success", worker.id, queue, job, result);
+    worker.on("success", (queue, job, result, duration) => {
+      this.emit("success", worker.id, queue, job, result, duration);
     });
-    worker.on("failure", (queue, job, failure) => {
-      this.emit("failure", worker.id, queue, job, failure);
+    worker.on("failure", (queue, job, failure, duration) => {
+      this.emit("failure", worker.id, queue, job, failure, duration);
     });
     worker.on("error", (error, queue, job) => {
       this.emit("error", error, worker.id, queue, job);


### PR DESCRIPTION
We now emit `duration` for success and failure events:

```ts
 worker.on("success", (queue, job, result, duration) => {
    console.log(
      `job success ${queue} ${JSON.stringify(job)} >> ${result} (${duration}ms)`
    );
  });

  worker.on("failure", (queue, job, failure, duration) => {
    console.log(
      `job failure ${queue} ${JSON.stringify(
        job
      )} >> ${failure} (${duration}ms)`
    );
  });
```