### PR TITLE
Update examples/scheduledJobs file link

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ If you know the name of a worker that should be removed, you can also call `awai
 
 You may want to use node-resque to schedule jobs every minute/hour/day, like a distributed CRON system. There are a number of excellent node packages to help you with this, like [node-schedule](https://github.com/tejasmanohar/node-schedule) and [node-cron](https://github.com/ncb000gt/node-cron). Node-resque makes it possible for you to use the package of your choice to schedule jobs with.
 
-Assuming you are running node-resque across multiple machines, you will need to ensure that only one of your processes is actually scheduling the jobs. To help you with this, you can inspect which of the scheduler processes is currently acting as master, and flag only the master scheduler process to run the schedule. A full example can be found at [/examples/scheduledJobs.js](https://github.com/actionhero/node-resque/blob/master/examples/scheduledJobs.js), but the relevant section is:
+Assuming you are running node-resque across multiple machines, you will need to ensure that only one of your processes is actually scheduling the jobs. To help you with this, you can inspect which of the scheduler processes is currently acting as master, and flag only the master scheduler process to run the schedule. A full example can be found at [/examples/scheduledJobs.ts](https://github.com/actionhero/node-resque/blob/master/examples/scheduledJobs.ts), but the relevant section is:
 
 ```javascript
 const NodeResque = require("node-resque");


### PR DESCRIPTION
Update examples/scheduledJobs file link in Job Schedules section. Was previously pointing to `https://github.com/actionhero/node-resque/blob/master/examples/scheduledJobs.js`, which 404s