### PR TITLE
Remove jobs definition of producer example

### DIFF
--- a/examples/docker/producer/producer.js
+++ b/examples/docker/producer/producer.js
@@ -7,22 +7,7 @@ async function boot() {
     host: process.env.REDIS_HOST,
   };
 
-  const jobs = {
-    add: {
-      perform: async (a, b) => {
-        const answer = a + b;
-        return answer;
-      },
-    },
-    subtract: {
-      perform: (a, b) => {
-        const answer = a - b;
-        return answer;
-      },
-    },
-  };
-
-  queue = new Queue({ connection: connectionDetails }, jobs);
+  queue = new Queue({ connection: connectionDetails });
   queue.on("error", function (error) {
     console.log(error);
   });


### PR DESCRIPTION
It's confusing to understand the architecture if I need to pass jobs definition on "client" and "server" side.

And it's said optional:
- https://github.com/actionhero/node-resque/issues/105#issuecomment-160808514

Perhaps the plugin related dependency should be noted in each of those plugins documentation, but it also could be an outdated statement:
- https://github.com/actionhero/node-resque/issues/105#issuecomment-160809983