### PR TITLE
process.nextTick() takes callback as argument

### DIFF
--- a/examples/docker/producer/producer.js
+++ b/examples/docker/producer/producer.js
@@ -36,19 +36,19 @@ function awaitHardStop() {
     console.error(
       `Process did not terminate within ${timeout}ms. Stopping now!`
     );
-    process.nextTick(process.exit(1));
+    process.nextTick(() => process.exit(1));
   }, timeout);
 }
 
 // handle errors & rejections
 process.on("uncaughtException", (error) => {
   console.error(error.stack);
-  process.nextTick(process.exit(1));
+  process.nextTick(() => process.exit(1));
 });
 
 process.on("unhandledRejection", (rejection) => {
   console.error(rejection.stack);
-  process.nextTick(process.exit(1));
+  process.nextTick(() => process.exit(1));
 });
 
 // handle signals

--- a/examples/docker/worker/worker.js
+++ b/examples/docker/worker/worker.js
@@ -119,19 +119,19 @@ function awaitHardStop() {
     console.error(
       `Process did not terminate within ${timeout}ms. Stopping now!`
     );
-    process.nextTick(process.exit(1));
+    process.nextTick(() => process.exit(1));
   }, timeout);
 }
 
 // handle errors & rejections
 process.on("uncaughtException", (error) => {
   console.error(error.stack);
-  process.nextTick(process.exit(1));
+  process.nextTick(() => process.exit(1));
 });
 
 process.on("unhandledRejection", (rejection) => {
   console.error(rejection.stack);
-  process.nextTick(process.exit(1));
+  process.nextTick(() => process.exit(1));
 });
 
 // handle signals


### PR DESCRIPTION
This fixes docker examples that pass argument result of `process.exit()`,
but `process.exit()` exits, so in reality, that tick is never called.