### PR TITLE
Add SubscribingEventEmitter class

### DIFF
--- a/__tests__/core/SubscribingEventEmitter.test.ts
+++ b/__tests__/core/SubscribingEventEmitter.test.ts
@@ -8,11 +8,31 @@ class Subscriber {
    */
   public events = {
     function: 0,
+    start: 0,
+    static: 0,
   };
+
+  public static staticEvents = {
+    static: 0,
+  };
+
+  onstart() {
+    // this this will throw if "this" is not resolved to current class
+    this.events["start"]++;
+  }
+
+  static staticMethod() {
+    Subscriber.staticEvents["static"]++;
+  }
 
   getSubscribedEvents() {
     return {
+      // inline callback
       function: () => this.events["function"]++,
+      // pointer to class method
+      start: this.onstart,
+      // using static method
+      static: Subscriber.staticMethod,
     };
   }
 }
@@ -34,9 +54,13 @@ describe("utils", () => {
       const worker = new Worker();
       const subscriber = new Subscriber();
       worker.addSubscriber(subscriber);
+      worker.emit("start");
       worker.emit("function");
+      worker.emit("static");
 
+      expect(subscriber.events["start"]).toBe(1);
       expect(subscriber.events["function"]).toBe(1);
+      expect(Subscriber.staticEvents["static"]).toBe(1);
     });
   });
 });

--- a/__tests__/core/SubscribingEventEmitter.test.ts
+++ b/__tests__/core/SubscribingEventEmitter.test.ts
@@ -1,0 +1,42 @@
+import { SubscribingEventEmitter } from "../../src/utils/SubscribingEventEmitter";
+
+class Worker extends SubscribingEventEmitter {}
+
+class Subscriber {
+  /**
+   * counter for invocations
+   */
+  public events = {
+    function: 0,
+  };
+
+  getSubscribedEvents() {
+    return {
+      function: () => this.events["function"]++,
+    };
+  }
+}
+
+describe("utils", () => {
+  describe("SubscribingEventEmitter", () => {
+    test("register/unregister listeners", async () => {
+      const worker = new Worker();
+      expect(worker.listenerCount("function")).toBe(0);
+
+      worker.addSubscriber(new Subscriber());
+      expect(worker.listenerCount("function")).toBe(1);
+
+      worker.removeAllListeners();
+      expect(worker.listenerCount("function")).toBe(0);
+    });
+
+    test("listerner is called", async () => {
+      const worker = new Worker();
+      const subscriber = new Subscriber();
+      worker.addSubscriber(subscriber);
+      worker.emit("function");
+
+      expect(subscriber.events["function"]).toBe(1);
+    });
+  });
+});

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -5,6 +5,7 @@ import { Jobs } from "../types/jobs";
 import { ConnectionOptions } from "../types/options";
 import { Connection } from "./connection";
 import { RunPlugins } from "./pluginRunner";
+import { SubscribingEventEmitter } from "../utils/SubscribingEventEmitter";
 
 function arrayify(o) {
   if (Array.isArray(o)) {
@@ -22,7 +23,7 @@ export declare interface Queue {
   on(event: "error", cb: (error: Error, queue: string) => void): this;
   once(event: "error", cb: (error: Error, queue: string) => void): this;
 }
-export class Queue extends EventEmitter {
+export class Queue extends SubscribingEventEmitter {
   constructor(options, jobs = {}) {
     super();
 

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -9,6 +9,7 @@ import { Jobs } from "../types/jobs";
 import { SchedulerOptions } from "../types/options";
 import { Connection } from "./connection";
 import { Queue } from "./queue";
+import { SubscribingEventEmitter } from "../utils/SubscribingEventEmitter";
 
 export declare interface Scheduler {
   options: SchedulerOptions;
@@ -58,7 +59,7 @@ export type SchedulerEvent =
   | "workingTimestamp"
   | "transferredJob";
 
-export class Scheduler extends EventEmitter {
+export class Scheduler extends SubscribingEventEmitter {
   constructor(options, jobs = {}) {
     super();
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -6,6 +6,7 @@ import { WorkerOptions } from "../types/options";
 import { Connection } from "./connection";
 import { RunPlugins } from "./pluginRunner";
 import { Queue } from "./queue";
+import { SubscribingEventEmitter } from "../utils/SubscribingEventEmitter";
 
 function prepareJobs(jobs) {
   return Object.keys(jobs).reduce(function (h, k) {
@@ -100,7 +101,7 @@ export type WorkerEvent =
   | "error"
   | "pause";
 
-export class Worker extends EventEmitter {
+export class Worker extends SubscribingEventEmitter {
   constructor(options, jobs = {}) {
     super();
 

--- a/src/utils/SubscribingEventEmitter.ts
+++ b/src/utils/SubscribingEventEmitter.ts
@@ -1,0 +1,15 @@
+import { EventEmitter } from "events";
+
+/**
+ * This adds addSubscriber() to EventEmitter class:
+ * @see https://nodejs.org/api/events.html
+ */
+export class SubscribingEventEmitter extends EventEmitter {
+  async addSubscriber(subscriber: any) {
+    let subscribedEvents = subscriber.getSubscribedEvents();
+    for (let [event, listener] of Object.entries(subscribedEvents)) {
+      // @ts-ignore
+      this.on(event, listener);
+    }
+  }
+}

--- a/src/utils/SubscribingEventEmitter.ts
+++ b/src/utils/SubscribingEventEmitter.ts
@@ -5,6 +5,20 @@ import { EventEmitter } from "events";
  * @see https://nodejs.org/api/events.html
  */
 export class SubscribingEventEmitter extends EventEmitter {
+  /**
+   * Add listeners to current class from a class "subscriber".
+   *
+   * The class must provide getSubscribedEvents() method
+   * that returns array of event name and listener pairs:
+   *
+   * getSubscribedEvents() {
+   *   return {
+   *      // this will subscribe to "example" event
+   *      "example": () => console.log("handler for exaple event called"),
+   *   };
+   * }
+   *
+   */
   async addSubscriber(subscriber: any) {
     let subscribedEvents = subscriber.getSubscribedEvents();
     for (let [event, listener] of Object.entries(subscribedEvents)) {


### PR DESCRIPTION
Problem: To register bulk of events, need to invoke ".on("eventname", handler) on each of the events, even handlers are coupled with the class itself, and class knows what events it wants to listen to.

Soliution: Add new class, which extends `EventEmitter` and adds `addSubscriber` method.

To make this appear for example to Worker class, it's parent must be updated:

```diff
diff --git a/src/core/worker.ts b/src/core/worker.ts
index 6d45c4b..761459a 100644
--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -6,6 +6,7 @@ import { WorkerOptions } from "../types/options";
 import { Connection } from "./connection";
 import { RunPlugins } from "./pluginRunner";
 import { Queue } from "./queue";
+import { SubscribingEventEmitter } from "../utils/SubscribingEventEmitter";

 function prepareJobs(jobs) {
   return Object.keys(jobs).reduce(function (h, k) {
@@ -100,7 +101,7 @@ export type WorkerEvent =
   | "error"
   | "pause";

-export class Worker extends EventEmitter {
+export class Worker extends SubscribingEventEmitter {
   constructor(options, jobs = {}) {
     super();
```