### PR TITLE
Extend docker example to use typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dump.rdb
 .idea/
 dist
 docs
+examples/docker/*/package-lock.json

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -26,4 +26,3 @@ services:
 
 networks:
   resque_network:
-    driver: overlay

--- a/examples/docker/producer/Dockerfile
+++ b/examples/docker/producer/Dockerfile
@@ -1,12 +1,15 @@
 
 FROM alpine:latest
-MAINTAINER admin@actionherojs.com
 
-WORKDIR /node-resque
+WORKDIR /node-resque-demo
 
 RUN apk add --update nodejs nodejs-npm
-COPY package.json .
-COPY producer.js .
-RUN npm install
 
-CMD ["node", "producer.js"]
+COPY package.json .
+COPY tsconfig.json .
+COPY src src
+
+# npm install will also run npm prepare, compiling the typescript
+RUN npm install --unsafe-perm
+
+CMD ["node", "dist/producer.js"]

--- a/examples/docker/producer/Dockerfile
+++ b/examples/docker/producer/Dockerfile
@@ -11,5 +11,6 @@ COPY src src
 
 # npm install will also run npm prepare, compiling the typescript
 RUN npm install --unsafe-perm
+RUN npm prune
 
 CMD ["node", "dist/producer.js"]

--- a/examples/docker/producer/package.json
+++ b/examples/docker/producer/package.json
@@ -8,7 +8,14 @@
     "type": "git",
     "url": "git://github.com/actionhero/node-resque.git"
   },
+  "scripts": {
+    "prepare": "tsc"
+  },
   "dependencies": {
     "node-resque": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "typescript": "latest"
   }
 }

--- a/examples/docker/producer/src/producer.ts
+++ b/examples/docker/producer/src/producer.ts
@@ -1,4 +1,5 @@
-import { Queue } from "../../../src";
+import { Queue } from "node-resque";
+
 /* In your projects:
 import { Queue } from require("node-resque");
 */
@@ -51,7 +52,7 @@ process.on("uncaughtException", (error) => {
 });
 
 process.on("unhandledRejection", (rejection) => {
-  console.error(rejection.stack);
+  console.error(rejection["stack"]);
   process.nextTick(() => process.exit(1));
 });
 

--- a/examples/docker/producer/tsconfig.json
+++ b/examples/docker/producer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "module": "commonjs",
+    "target": "es2018"
+  },
+  "include": ["./src/**/*"]
+}

--- a/examples/docker/worker/Dockerfile
+++ b/examples/docker/worker/Dockerfile
@@ -11,5 +11,6 @@ COPY src src
 
 # npm install will also run npm prepare, compiling the typescript
 RUN npm install --unsafe-perm
+RUN npm prune
 
 CMD ["node", "dist/worker.js"]

--- a/examples/docker/worker/Dockerfile
+++ b/examples/docker/worker/Dockerfile
@@ -1,12 +1,15 @@
 
 FROM alpine:latest
-MAINTAINER admin@actionherojs.com
 
-WORKDIR /node-resque
+WORKDIR /node-resque-demo
 
 RUN apk add --update nodejs nodejs-npm
-COPY package.json .
-COPY worker.js .
-RUN npm install
 
-CMD ["node", "worker.js"]
+COPY package.json .
+COPY tsconfig.json .
+COPY src src
+
+# npm install will also run npm prepare, compiling the typescript
+RUN npm install --unsafe-perm
+
+CMD ["node", "dist/worker.js"]

--- a/examples/docker/worker/package.json
+++ b/examples/docker/worker/package.json
@@ -8,7 +8,14 @@
     "type": "git",
     "url": "git://github.com/actionhero/node-resque.git"
   },
+  "scripts": {
+    "prepare": "tsc"
+  },
   "dependencies": {
     "node-resque": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "typescript": "latest"
   }
 }

--- a/examples/docker/worker/src/worker.ts
+++ b/examples/docker/worker/src/worker.ts
@@ -1,4 +1,5 @@
-import { Worker, Scheduler } from "../../../src";
+import { Worker, Scheduler } from "node-resque";
+
 /* In your projects:
 const { Worker, Scheduler } = require("node-resque");
 */
@@ -133,7 +134,7 @@ process.on("uncaughtException", (error) => {
 });
 
 process.on("unhandledRejection", (rejection) => {
-  console.error(rejection.stack);
+  console.error(rejection["stack"]);
   process.nextTick(() => process.exit(1));
 });
 

--- a/examples/docker/worker/tsconfig.json
+++ b/examples/docker/worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "module": "commonjs",
+    "target": "es2018"
+  },
+  "include": ["./src/**/*"]
+}


### PR DESCRIPTION
The docker examples now use a typescript source, and compile it as part of the `docker build` & `docker-compose up` steps