### PR TITLE
resque-web: support RAILS_RESQUE_REDIS env

### DIFF
--- a/resque-web/config.ru
+++ b/resque-web/config.ru
@@ -8,14 +8,11 @@ require 'resque-retry'
 require 'resque-retry/server'
 require 'yaml'
 
-Resque.redis = Redis.new
-
-# Or, with custom options
-# Resque.redis = Redis.new({
-#   :host => "127.0.0.1",
-#   :port => 6379,
-#   :db => 1,
-# })
+Resque.redis = Redis.new({
+  :host => ENV['RAILS_RESQUE_REDIS'].present? ? ENV['RAILS_RESQUE_REDIS'] : '127.0.0.1',
+  :port => 6379,
+#  :db => 1,
+})
 # Resque.redis.namespace = 'resque_test'
 
 run Rack::URLMap.new \

--- a/resque-web/config.ru
+++ b/resque-web/config.ru
@@ -9,7 +9,7 @@ require 'resque-retry/server'
 require 'yaml'
 
 Resque.redis = Redis.new({
-  :host => ENV['RAILS_RESQUE_REDIS'].present? ? ENV['RAILS_RESQUE_REDIS'] : '127.0.0.1',
+  :host => !ENV['RAILS_RESQUE_REDIS'].nil? ? ENV['RAILS_RESQUE_REDIS'] : '127.0.0.1',
   :port => 6379,
 #  :db => 1,
 })


### PR DESCRIPTION
I used this project config.ru to start resque-web.

Needed to override redis hostname, as it was different container.

This matches the environment variable used in `resque-web/`[config/initializers/resque_config.rb]

[config/initializers/resque_config.rb]: https://github.com/resque/resque-web/blob/717bc8d08a5b04fa98007cc96086796dc274264d/config/initializers/resque_config.rb