### PR TITLE
Add links to "domain" in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,16 @@ You can work with these failed jobs with the following methods:
 
 ### Failing a Job
 
-We use a try/catch pattern to catch errors in your jobs. If any job throws an uncaught exception, it will be caught, and the job's payload moved to the error queue for inspection. Do not use `domains`, `process.onExit`, or any other method of "catching" a process crash. The error payload looks like:
+We use a try/catch pattern to catch errors in your jobs. If any job throws an
+uncaught exception, it will be caught, and the job's payload moved to the error
+queue for inspection.
+Do not use [domain], [process.on("exit")][process.onexit], or any other method
+of "catching" a process crash.
+
+[domain]: https://nodejs.org/api/domain.html
+[process.onexit]: https://nodejs.org/api/process.html#process_event_exit
+
+The error payload looks like:
 
 ```javascript
 { worker: 'busted-worker-3',

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ worker.start();
 You can also pass redis client directly.
 
 ```javascript
-// assume you already initialize redis client before
+// assume you already initialized redis client before
 
 var redisClient = new Redis();
 var connectionDetails = { redis: redisClient };


### PR DESCRIPTION
the sentence "don't use `domains` looked very weird", confusing and misleading. so dug up in the history what the hell it means. appears it's domain node module. so updated docs to point to documentation so my time spent on the investigation isn't lost

I also took the liberty to reformat the block to readable width, like you force reformat code with prettier.

refs:
- ceaa9c6d9935f38b076fbaf85246c427772ac573
- #167