### PR TITLE
Workers with wildcard queue will find new queues

### DIFF
--- a/__tests__/core/worker.ts
+++ b/__tests__/core/worker.ts
@@ -165,131 +165,163 @@ describe("worker", () => {
     });
 
     describe("integration", () => {
-      beforeEach(async () => {
-        worker = new Worker(
+      test("will notice new job queues when started with queues=*", async (done) => {
+        const wildcardWorker = new Worker(
           {
             connection: specHelper.connectionDetails,
             timeout: specHelper.timeout,
-            queues: [specHelper.queue],
+            queues: ["*"],
           },
           jobs
         );
-        await worker.connect();
-      });
 
-      afterEach(async () => {
-        await worker.end();
-      });
+        await wildcardWorker.connect();
+        await wildcardWorker.start();
 
-      test("will mark a job as failed", async (done) => {
-        await queue.enqueue(specHelper.queue, "badAdd", [1, 2]);
+        setTimeout(async () => {
+          await queue.enqueue("__newQueue", "add", [1, 2]);
+        }, 501);
 
-        await worker.start();
-
-        worker.on("failure", (q, job, failire) => {
-          expect(q).toBe(specHelper.queue);
-          expect(job.class).toBe("badAdd");
-          expect(failire.message).toBe("Blue Smoke");
-
-          worker.removeAllListeners("failire");
-          done();
-        });
-      });
-
-      test("can work a job and return successful things", async (done) => {
-        await queue.enqueue(specHelper.queue, "add", [1, 2]);
-
-        worker.start();
-
-        worker.on("success", (q, job, result, duration) => {
-          expect(q).toBe(specHelper.queue);
+        wildcardWorker.on("success", async (q, job, result, duration) => {
+          expect(q).toBe("__newQueue");
           expect(job.class).toBe("add");
           expect(result).toBe(3);
-          expect(worker.result).toBe(result);
+          expect(wildcardWorker.result).toBe(result);
           expect(duration).toBeGreaterThanOrEqual(0);
 
-          worker.removeAllListeners("success");
+          wildcardWorker.removeAllListeners("success");
+          await wildcardWorker.end();
           done();
         });
       });
 
-      // TODO: Typescript seems to have trouble with frozen objects
-      // test('job arguments are immutable', async (done) => {
-      //   await queue.enqueue(specHelper.queue, 'messWithData', { a: 'starting value' })
-
-      //   worker.start()
-
-      //   worker.on('success', (q, job, result) => {
-      //     expect(result.a).toBe('starting value')
-      //     expect(worker.result).toBe(result)
-
-      //     worker.removeAllListeners('success')
-      //     done()
-      //   })
-      // })
-
-      test("can accept jobs that are simple functions", async (done) => {
-        await queue.enqueue(specHelper.queue, "quickDefine");
-
-        worker.start();
-
-        worker.on("success", (q, job, result, duration) => {
-          expect(result).toBe("ok");
-          expect(duration).toBeGreaterThanOrEqual(0);
-          worker.removeAllListeners("success");
-          done();
-        });
-      });
-
-      test("will not work jobs that are not defined", async (done) => {
-        await queue.enqueue(specHelper.queue, "somethingFake");
-
-        worker.start();
-
-        worker.on("failure", (q, job, failure, duration) => {
-          expect(q).toBe(specHelper.queue);
-          expect(String(failure)).toBe(
-            'Error: No job defined for class "somethingFake"'
+      describe("with worker", () => {
+        beforeEach(async () => {
+          worker = new Worker(
+            {
+              connection: specHelper.connectionDetails,
+              timeout: specHelper.timeout,
+              queues: [specHelper.queue],
+            },
+            jobs
           );
-          expect(duration).toBeGreaterThanOrEqual(0);
-
-          worker.removeAllListeners("failure");
-          done();
-        });
-      });
-
-      test("will place failed jobs in the failed queue", async () => {
-        let data = await specHelper.redis.rpop(
-          specHelper.namespace + ":" + "failed"
-        );
-        data = JSON.parse(data);
-        expect(data.queue).toBe(specHelper.queue);
-        expect(data.exception).toBe("Error");
-        expect(data.error).toBe('No job defined for class "somethingFake"');
-      });
-
-      test("will ping with status even when working a slow job", async (done) => {
-        const nowInSeconds = Math.round(new Date().getTime() / 1000);
-        await worker.start();
-        await new Promise((resolve) =>
-          setTimeout(resolve, worker.options.timeout * 2)
-        );
-        const pingKey = worker.connection.key("worker", "ping", worker.name);
-        const firstPayload = JSON.parse(await specHelper.redis.get(pingKey));
-        expect(firstPayload.name).toEqual(worker.name);
-        expect(firstPayload.time).toBeGreaterThanOrEqual(nowInSeconds);
-
-        await queue.enqueue(specHelper.queue, "twoSeconds");
-
-        worker.on("success", (q, job, result) => {
-          expect(result).toBe("slow");
-          worker.removeAllListeners("success");
-          done();
+          await worker.connect();
         });
 
-        const secondPayload = JSON.parse(await specHelper.redis.get(pingKey));
-        expect(secondPayload.name).toEqual(worker.name);
-        expect(secondPayload.time).toBeGreaterThanOrEqual(firstPayload.time);
+        afterEach(async () => {
+          await worker.end();
+        });
+
+        test("will mark a job as failed", async (done) => {
+          await queue.enqueue(specHelper.queue, "badAdd", [1, 2]);
+
+          await worker.start();
+
+          worker.on("failure", (q, job, failire) => {
+            expect(q).toBe(specHelper.queue);
+            expect(job.class).toBe("badAdd");
+            expect(failire.message).toBe("Blue Smoke");
+
+            worker.removeAllListeners("failire");
+            done();
+          });
+        });
+
+        test("can work a job and return successful things", async (done) => {
+          await queue.enqueue(specHelper.queue, "add", [1, 2]);
+
+          worker.start();
+
+          worker.on("success", (q, job, result, duration) => {
+            expect(q).toBe(specHelper.queue);
+            expect(job.class).toBe("add");
+            expect(result).toBe(3);
+            expect(worker.result).toBe(result);
+            expect(duration).toBeGreaterThanOrEqual(0);
+
+            worker.removeAllListeners("success");
+            done();
+          });
+        });
+
+        // TODO: Typescript seems to have trouble with frozen objects
+        // test('job arguments are immutable', async (done) => {
+        //   await queue.enqueue(specHelper.queue, 'messWithData', { a: 'starting value' })
+
+        //   worker.start()
+
+        //   worker.on('success', (q, job, result) => {
+        //     expect(result.a).toBe('starting value')
+        //     expect(worker.result).toBe(result)
+
+        //     worker.removeAllListeners('success')
+        //     done()
+        //   })
+        // })
+
+        test("can accept jobs that are simple functions", async (done) => {
+          await queue.enqueue(specHelper.queue, "quickDefine");
+
+          worker.start();
+
+          worker.on("success", (q, job, result, duration) => {
+            expect(result).toBe("ok");
+            expect(duration).toBeGreaterThanOrEqual(0);
+            worker.removeAllListeners("success");
+            done();
+          });
+        });
+
+        test("will not work jobs that are not defined", async (done) => {
+          await queue.enqueue(specHelper.queue, "somethingFake");
+
+          worker.start();
+
+          worker.on("failure", (q, job, failure, duration) => {
+            expect(q).toBe(specHelper.queue);
+            expect(String(failure)).toBe(
+              'Error: No job defined for class "somethingFake"'
+            );
+            expect(duration).toBeGreaterThanOrEqual(0);
+
+            worker.removeAllListeners("failure");
+            done();
+          });
+        });
+
+        test("will place failed jobs in the failed queue", async () => {
+          let data = await specHelper.redis.rpop(
+            specHelper.namespace + ":" + "failed"
+          );
+          data = JSON.parse(data);
+          expect(data.queue).toBe(specHelper.queue);
+          expect(data.exception).toBe("Error");
+          expect(data.error).toBe('No job defined for class "somethingFake"');
+        });
+
+        test("will ping with status even when working a slow job", async (done) => {
+          const nowInSeconds = Math.round(new Date().getTime() / 1000);
+          await worker.start();
+          await new Promise((resolve) =>
+            setTimeout(resolve, worker.options.timeout * 2)
+          );
+          const pingKey = worker.connection.key("worker", "ping", worker.name);
+          const firstPayload = JSON.parse(await specHelper.redis.get(pingKey));
+          expect(firstPayload.name).toEqual(worker.name);
+          expect(firstPayload.time).toBeGreaterThanOrEqual(nowInSeconds);
+
+          await queue.enqueue(specHelper.queue, "twoSeconds");
+
+          worker.on("success", (q, job, result) => {
+            expect(result).toBe("slow");
+            worker.removeAllListeners("success");
+            done();
+          });
+
+          const secondPayload = JSON.parse(await specHelper.redis.get(pingKey));
+          expect(secondPayload.name).toEqual(worker.name);
+          expect(secondPayload.time).toBeGreaterThanOrEqual(firstPayload.time);
+        });
       });
     });
   });

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -191,9 +191,7 @@ export class Worker extends EventEmitter {
   }
 
   private async poll(nQueue = 0) {
-    if (!this.running) {
-      return;
-    }
+    if (!this.running) return;
 
     this.queue = this.queues[nQueue];
     this.emit("poll", this.queue);
@@ -227,6 +225,7 @@ export class Worker extends EventEmitter {
       } else {
         this.working = false;
         if (nQueue === this.queues.length - 1) {
+          if (this.originalQueue === "*") await this.checkQueues();
           await this.pause();
           return null;
         } else {
@@ -492,7 +491,8 @@ export class Worker extends EventEmitter {
 
     if (
       (this.queues[0] === "*" && this.queues.length === 1) ||
-      this.queues.length === 0
+      this.queues.length === 0 ||
+      this.originalQueue === "*"
     ) {
       this.originalQueue = "*";
       await this.untrack();


### PR DESCRIPTION
If `worker.queues = ['*']`, this PR adds functionality to re-scan the list of queues that exist before every `worker#sleep`.  In this way, if the worker has no jobs to perform in the queues it knows about, it will check for new queues.

closes https://github.com/actionhero/node-resque/issues/412