### PR TITLE
Add support for IORedis.Cluster type in ConnectionOptions for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,13 @@ You can also pass redis client directly.
 
 ```javascript
 // assume you already initialized redis client before
+// the "redis" key can be IORedis.Redis or IORedis.Cluster instance
 
 var redisClient = new Redis();
 var connectionDetails = { redis: redisClient };
+
+var redisCluster = new Cluster();
+var connectionDetails = { redis: redisCluster };
 
 var worker = new NodeResque.Worker(
   { connection: connectionDetails, queues: "math" },

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -12,7 +12,7 @@ export class Connection extends EventEmitter {
   options: ConnectionOptions | null;
   private eventListeners: EventListeners;
   connected: boolean;
-  redis: IORedis.Redis;
+  redis: IORedis.Redis | IORedis.Cluster;
 
   constructor(options: ConnectionOptions = {}) {
     super();

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -10,7 +10,7 @@ export interface ConnectionOptions {
   namespace?: string;
   looping?: boolean;
   options?: any;
-  redis?: IORedis.Redis;
+  redis?: IORedis.Redis | IORedis.Cluster;
   scanCount?: number;
 }
 


### PR DESCRIPTION
I don't see explicitly said out that the project supports Redis cluster, neither I do see that it's been spelled out it does not work, but I do see that people talk about it, likely in javascript not in typescript that they have not encountered this problem, example https://github.com/actionhero/node-resque/issues/158

```
error TS2345: Argument of type '{ redis: IORedis.Redis | IORedis.Cluster; }' is not assignable to parameter of type 'ConnectionOptions'.
#15 5.391   Types of property 'redis' are incompatible.
#15 5.391     Type 'Redis | Cluster' is not assignable to type 'Redis | undefined'.
#15 5.391       Type 'Cluster' is missing the following properties from type 'Redis': Promise, duplicate, send_command
```

this PR adds `{ redis: IORedis.Redis | IORedis.Cluster; }` typing for ConnectionOptions

cc @evantahler 