### PR TITLE
JobLock option reEnqueue to skip trying job again

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ async function boot() {
     add: {
       plugins: ["JobLock"],
       pluginOptions: {
-        JobLock: {},
+        JobLock: { reEnqueue: true },
       },
       perform: async (a, b) => {
         await new Promise((resolve) => {

--- a/__tests__/utils/specHelper.ts
+++ b/__tests__/utils/specHelper.ts
@@ -39,9 +39,7 @@ const SpecHelper = {
 
   cleanup: async function () {
     const keys = await this.redis.keys(this.namespace + "*");
-    if (keys.length > 0) {
-      await this.redis.del(keys);
-    }
+    if (keys.length > 0) await this.redis.del(keys);
   },
 
   disconnect: async function () {

--- a/src/plugins/JobLock.ts
+++ b/src/plugins/JobLock.ts
@@ -25,7 +25,15 @@ export class JobLock extends Plugin {
     if (lockedByMe && lockedByMe.toString().toLowerCase() === "ok") {
       return true;
     } else {
-      await this.reEnqueue();
+      const options = this.job.pluginOptions;
+      const toReEnqueue = options.JobLock
+        ? options.JobLock.reEnqueue !== null &&
+          options.JobLock.reEnqueue !== undefined
+          ? options.JobLock.reEnqueue
+          : true
+        : true;
+
+      if (toReEnqueue) await this.reEnqueue();
       return false;
     }
   }


### PR DESCRIPTION
This PR adds a new plugin setting for `JobLock` to skip re-enqueuing the job if another instance of the job is already being worked on.

```ts
const jobs = {
  withReEnqueue: {
    plugins: ["JobLock"],
    pluginOptions: {},  // or the default { JobLock: { reEnqueue: true } },
    perform: async () => {
      return "hi";
    },
  },
  withoutReEnqueue: {
    plugins: ["JobLock"],
    pluginOptions: { JobLock: { reEnqueue: false } },
    perform: async () => {
      return "hi";
    },
  },
};
```