### PR TITLE
Resilience Updates

### DIFF
--- a/__tests__/core/connection.ts
+++ b/__tests__/core/connection.ts
@@ -47,7 +47,7 @@ describe("connection", () => {
 
   describe("keys and namespaces", () => {
     const db = specHelper.connectionDetails.database;
-    let connection;
+    let connection: Connection;
     beforeAll(async () => {
       connection = new Connection(specHelper.cleanConnectionDetails());
       await connection.connect();
@@ -144,6 +144,7 @@ describe("connection", () => {
     });
 
     test("keys built with a array namespace are correct", () => {
+      //@ts-ignore
       connection.options.namespace = ["custom", "namespace"];
       expect(connection.key("thing")).toBe("custom:namespace:thing");
 

--- a/__tests__/core/connection.ts
+++ b/__tests__/core/connection.ts
@@ -15,7 +15,7 @@ describe("connection", () => {
 
   test(
     "can provide an error if connection failed",
-    async () => {
+    async (resolve) => {
       const connectionDetails = {
         pkg: specHelper.connectionDetails.pkg,
         host: "wrong-hostname",
@@ -27,14 +27,12 @@ describe("connection", () => {
 
       const connection = new Connection(connectionDetails);
 
-      await new Promise((resolve) => {
-        connection.connect();
+      connection.connect();
 
-        connection.on("error", (error) => {
-          expect(error.message).toMatch(/ENOTFOUND|ETIMEDOUT|ECONNREFUSED/);
-          connection.end();
-          resolve();
-        });
+      connection.on("error", (error) => {
+        expect(error.message).toMatch(/ENOTFOUND|ETIMEDOUT|ECONNREFUSED/);
+        connection.end();
+        resolve();
       });
     },
     30 * 1000

--- a/__tests__/core/multiWorker.ts
+++ b/__tests__/core/multiWorker.ts
@@ -129,24 +129,19 @@ describe("multiWorker", () => {
     30 * 1000
   );
 
-  test("should pass on all worker emits to the instance of multiWorker", async () => {
+  test("should pass on all worker emits to the instance of multiWorker", async (resolve) => {
     await queue.enqueue(specHelper.queue, "missingJob", []);
 
-    await new Promise((resolve, reject) => {
-      multiWorker.start();
+    multiWorker.start();
 
-      multiWorker.on(
-        "failure",
-        async (workerId, queue, job, error, duration) => {
-          expect(String(error)).toBe(
-            'Error: No job defined for class "missingJob"'
-          );
-          expect(duration).toBeGreaterThanOrEqual(0);
-          multiWorker.removeAllListeners("error");
-          await multiWorker.end();
-          resolve();
-        }
+    multiWorker.on("failure", async (workerId, queue, job, error, duration) => {
+      expect(String(error)).toBe(
+        'Error: No job defined for class "missingJob"'
       );
+      expect(duration).toBeGreaterThanOrEqual(0);
+      multiWorker.removeAllListeners("error");
+      await multiWorker.end();
+      resolve();
     });
   });
 });

--- a/__tests__/core/multiWorker.ts
+++ b/__tests__/core/multiWorker.ts
@@ -1,8 +1,8 @@
 import specHelper from "../utils/specHelper";
 import { MultiWorker, Queue } from "../../src";
 
-let queue;
-let multiWorker;
+let queue: Queue;
+let multiWorker: MultiWorker;
 const checkTimeout = specHelper.timeout / 10;
 const minTaskProcessors = 1;
 const maxTaskProcessors = 5;

--- a/__tests__/core/scheduler.ts
+++ b/__tests__/core/scheduler.ts
@@ -1,8 +1,8 @@
 import { Queue, Scheduler, Worker } from "../../src";
 import specHelper from "../utils/specHelper";
 
-let scheduler;
-let queue;
+let scheduler: Scheduler;
+let queue: Queue;
 
 describe("scheduler", () => {
   test("can connect", async () => {

--- a/__tests__/core/worker.ts
+++ b/__tests__/core/worker.ts
@@ -39,8 +39,8 @@ const jobs = {
   },
 };
 
-let worker;
-let queue;
+let worker: Worker;
+let queue: Queue;
 
 describe("worker", () => {
   afterAll(async () => {
@@ -159,6 +159,7 @@ describe("worker", () => {
       await worker.checkQueues();
       expect(worker.queues).toEqual([specHelper.queue]);
 
+      //@ts-ignore
       await queue.del(specHelper.queue);
       await worker.end();
     });
@@ -221,7 +222,7 @@ describe("worker", () => {
             expect(job.class).toBe("badAdd");
             expect(failire.message).toBe("Blue Smoke");
 
-            worker.removeAllListeners("failire");
+            worker.removeAllListeners("failure");
             done();
           });
         });

--- a/__tests__/plugins/jobLock.ts
+++ b/__tests__/plugins/jobLock.ts
@@ -22,7 +22,9 @@ const jobs = {
     plugins: ["JobLock"],
     pluginOptions: { JobLock: { reEnqueue: false } },
     perform: async () => {
-      return "hi";
+      await new Promise((resolve) => {
+        setTimeout(resolve, jobDelay);
+      });
     },
   },
 };

--- a/__tests__/plugins/jobLock.ts
+++ b/__tests__/plugins/jobLock.ts
@@ -301,7 +301,7 @@ describe("plugins", () => {
           await worker1.end();
           await worker2.end();
           const delta = new Date().getTime() - startTime;
-          expect(delta).toBeLessThan(jobDelay * 2);
+          expect(delta).toBeLessThan(jobDelay * 3);
           done();
         }
       };

--- a/__tests__/plugins/jobLock.ts
+++ b/__tests__/plugins/jobLock.ts
@@ -90,7 +90,7 @@ describe("plugins", () => {
           if (completed === 2) {
             worker1.end();
             worker2.end();
-            expect(new Date().getTime() - startTime).toBeLessThan(jobDelay * 2);
+            expect(new Date().getTime() - startTime).toBeLessThan(jobDelay * 3);
             resolve();
           }
         };

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -327,7 +327,7 @@ export class Queue extends EventEmitter {
    * - returns a hash of the form: `{ 'host:pid': 'queue1, queue2', 'host:pid': 'queue1, queue2' }`
    */
   async workers() {
-    const workers = {};
+    const workers: { [key: string]: any } = {};
 
     const results = await this.connection.redis.smembers(
       this.connection.key("workers")
@@ -367,7 +367,7 @@ export class Queue extends EventEmitter {
    * - returns a hash of the results of `queue.workingOn` with the worker names as keys.
    */
   async allWorkingOn() {
-    const results = {};
+    const results: { [key: string]: any } = {};
 
     const workers = await this.workers();
     for (const i in Object.keys(workers)) {
@@ -450,7 +450,7 @@ export class Queue extends EventEmitter {
   async cleanOldWorkers(age: number) {
     // note: this method will remove the data created by a 'stuck' worker and move the payload to the error queue
     // however, it will not actually remove any processes which may be running.  A job *may* be running that you have removed
-    const results = {};
+    const results: { [key: string]: any } = {};
 
     const data = await this.allWorkingOn();
     for (const i in Object.keys(data)) {
@@ -524,10 +524,10 @@ export class Queue extends EventEmitter {
     let batchSize = 100;
     let failedJobs = [];
 
-    async function loadFailedJobs() {
+    const loadFailedJobs = async () => {
       failedJobs = await this.failed(start, start + batchSize);
       start = start + batchSize;
-    }
+    };
 
     await loadFailedJobs();
 
@@ -547,7 +547,7 @@ export class Queue extends EventEmitter {
    * - stats will be a hash containing details about all the queues in your redis, and how many jobs are in each
    */
   async stats() {
-    const data = {};
+    const data: { [key: string]: any } = {};
     const keys = await this.connection.getKeys(this.connection.key("stat:*"));
     if (keys.length === 0) {
       return data;

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -67,6 +67,7 @@ export class Scheduler extends EventEmitter {
       stuckWorkerTimeout: 60 * 60 * 1000, // 60 minutes in ms
       leaderLockTimeout: 60 * 3, // in seconds
       name: os.hostname() + ":" + process.pid, // assumes only one worker per node process
+      retryStuckJobs: false,
     };
 
     for (const i in defaults) {
@@ -313,6 +314,10 @@ export class Scheduler extends EventEmitter {
       if (delta > stuckWorkerTimeoutInSeconds) {
         await this.forceCleanWorker(name, delta);
       }
+    }
+
+    if (this.options.retryStuckJobs === true) {
+      await this.queue.retryStuckJobs();
     }
   }
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -316,13 +316,10 @@ export class Worker extends EventEmitter {
   // #performInline is used to run a job payload directly.
   // If you are planning on running a job via #performInline, this worker should also not be started, nor should be using event emitters to monitor this worker.
   // This method will also not write to redis at all, including logging errors, modify resque's stats, etc.
-  async performInline(func, args) {
+  async performInline(func, args = []) {
     const q = "_direct-queue-" + this.name;
     let toRun;
 
-    if (!args) {
-      args = [];
-    }
     if (!(args instanceof Array)) {
       args = [args];
     }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -26,6 +26,7 @@ export interface SchedulerOptions extends ConnectionOptions {
   timeout?: number;
   leaderLockTimeout: number;
   stuckWorkerTimeout: number;
+  retryStuckJobs: boolean;
 }
 
 export interface MultiWorkerOptions extends ConnectionOptions {


### PR DESCRIPTION
1. Move the act of `pop`ing a job off of a queue to a [transaction](https://redis.io/topics/transactions) via `watch` and `multi`.
    * This will have speed implications.  In a busy system, the occurrences of trying to `"pop"` while writes are happening is high.  
    * We may want to move to a LUA implementation to be truly blocking

2. Add `queue.retryStuckJobs()` which is a single method to retry jobs which have failed due to the worker timeout.  

3. Add `options.retryStuckJobs`  to the Scheduler, to automatically run the above `queue.retryStuckJobs()` periodically.

If we can gain certainty that a job can't be lost between `pop`ing it and working it... and we have ways to retry stuck jobs, we can be rather sure we can't loose any jobs!