### PR TITLE
Use a Lua command within redis to pop a job and store it on the worker object

### DIFF
--- a/__tests__/core/connection.ts
+++ b/__tests__/core/connection.ts
@@ -43,6 +43,13 @@ describe("connection", () => {
     expect(keys.length).toBe(0);
   });
 
+  test("it has loaded Lua commands", async () => {
+    const connection = new Connection(specHelper.cleanConnectionDetails());
+    await connection.connect();
+    expect(typeof connection.redis["popAndStoreJob"]).toBe("function");
+    connection.end();
+  });
+
   describe("keys and namespaces", () => {
     const db = specHelper.connectionDetails.database;
     let connection: Connection;

--- a/lua/popAndStoreJob.lua
+++ b/lua/popAndStoreJob.lua
@@ -1,0 +1,24 @@
+-- { "numberOfKeys": 2 }
+
+-- Keys:
+--   1 - Queue Key
+--   2 - Worker Key
+
+-- Args
+--   1 - Date
+--   2 - Queue Name
+--   3 - Worker Name
+
+local payload = redis.call('lpop', KEYS[1])
+
+if payload then
+  local workerPayload = {}
+  workerPayload['run_at'] = ARGV[1]
+  workerPayload['queue'] = ARGV[2]
+  workerPayload['payload'] = cjson.decode(payload)
+  workerPayload['worker'] = ARGV[3]
+
+  redis.call('set', KEYS[2], cjson.encode(workerPayload))
+end
+
+return payload


### PR DESCRIPTION
In https://github.com/actionhero/node-resque/pull/450 we replaced 2 non-atomic commands to pop a job from a list and then a set command to save the job to the worker metadata with a transaction using a redis pipeline.  However, this was flawed as it is possible that between the initial reading of the job and the pop the job obtained was not what was expected.  

This PR moves to use a Lua script to atomically (within the redis srerver) both pop the job from the list and write it to the Worker's metadata.