### PR TITLE
Analyze LUA file lines with \n not EOL

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -102,7 +102,7 @@ export class Connection extends EventEmitter {
       const file = files[i];
       const { name } = path.parse(file);
       const contents = fs.readFileSync(path.join(luaDir, file)).toString();
-      const lines = contents.split(os.EOL);
+      const lines = contents.split("\n"); // see https://github.com/actionhero/node-resque/issues/465 for why we split only on *nix line breaks
       const encodedMetadata = lines[0].replace(/^-- /, "");
       const metadata = JSON.parse(encodedMetadata);
 


### PR DESCRIPTION
Closes https://github.com/actionhero/node-resque/issues/465

As the LUA files are authored in a OSX/Linux environment, we need to split the lines of the file by `\n`, not `os.EOL`, even in Windows environments. 