### PR TITLE
Plugin Classes gain name of constructor

### DIFF
--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -17,7 +17,7 @@ export abstract class Plugin {
   };
 
   constructor(worker, func, queue, job, args, options) {
-    this.name = "CustomPlugin";
+    this.name = this?.constructor?.name || "Node Resque Plugin";
     this.worker = worker;
     this.queue = queue;
     this.func = func;

--- a/src/core/pluginRunner.ts
+++ b/src/core/pluginRunner.ts
@@ -7,12 +7,8 @@ export async function RunPlugins(
   args,
   pluginCounter?
 ) {
-  if (!pluginCounter) {
-    pluginCounter = 0;
-  }
-  if (!job) {
-    return true;
-  }
+  if (!pluginCounter) pluginCounter = 0;
+  if (!job) return true;
   if (
     job.plugins === null ||
     job.plugins === undefined ||
@@ -20,9 +16,7 @@ export async function RunPlugins(
   ) {
     return true;
   }
-  if (pluginCounter >= job.plugins.length) {
-    return true;
-  }
+  if (pluginCounter >= job.plugins.length) return true;
 
   const pluginRefrence = job.plugins[pluginCounter];
   const toRun = await RunPlugin(
@@ -35,9 +29,7 @@ export async function RunPlugins(
     args
   );
   pluginCounter++;
-  if (toRun === false) {
-    return false;
-  }
+  if (toRun === false) return false;
 
   return RunPlugins(self, type, func, queue, job, args, pluginCounter);
 }
@@ -51,9 +43,7 @@ export async function RunPlugin(
   job,
   args
 ) {
-  if (!job) {
-    return true;
-  }
+  if (!job) return true;
 
   let pluginName = PluginRefrence;
   if (typeof PluginRefrence === "function") {


### PR DESCRIPTION
This PR changes the `this.name` attribute of plugin classes to match the name of the class.  For example, now `new JobLock()` will have `this.name = 'JobLock'`.  

While possibly useful in debugging, this is important to un-block https://github.com/actionhero/node-resque/pull/479, which currently will consider each instance of a plugin the same as the base class.