### PR TITLE
Queues can see who the leader/scheduler is

### DIFF
--- a/__tests__/core/queue.ts
+++ b/__tests__/core/queue.ts
@@ -317,6 +317,12 @@ describe("queue", () => {
       expect(Object.keys(hashThree)).toHaveLength(0);
     });
 
+    test("can determine who the leader is", async () => {
+      await queue.connection.redis.set(queue.leaderKey(), "the_scheduler");
+      let leader = await queue.leader();
+      expect(leader).toBe("the_scheduler");
+    });
+
     test("can load stats", async () => {
       await queue.connection.redis.set(
         specHelper.namespace + ":stat:failed",

--- a/__tests__/core/scheduler.ts
+++ b/__tests__/core/scheduler.ts
@@ -120,6 +120,13 @@ describe("scheduler", () => {
         await queue.end();
       });
 
+      test("queues can see who the leader is", async () => {
+        await scheduler.poll();
+        const leader = await queue.leader();
+        expect(leader).toBe(scheduler.options.name);
+        await scheduler.end();
+      });
+
       test("will move enqueued jobs when the time comes", async () => {
         await queue.enqueueAt(1000 * 10, specHelper.queue, "someJob", [
           1,

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -166,7 +166,7 @@ export class Connection extends EventEmitter {
     this.connected = false;
   }
 
-  key(arg: any, arg2?: any, arg3?: any, arg4?: any) {
+  key(arg: any, arg2?: any, arg3?: any, arg4?: any): string {
     let args;
     args = arguments.length >= 1 ? [].slice.call(arguments, 0) : [];
     if (Array.isArray(this.options.namespace)) {

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -551,7 +551,14 @@ export class Queue extends EventEmitter {
   }
 
   /**
-   * - stats will be a hash containing details about all the queues in your redis, and how many jobs are in each
+   * Return the currently elected leader
+   */
+  async leader() {
+    return this.connection.redis.get(this.leaderKey());
+  }
+
+  /**
+   * - stats will be a hash containing details about all the queues in your redis, and how many jobs are in each, and who the leader is
    */
   async stats() {
     const data: { [key: string]: any } = {};
@@ -568,5 +575,12 @@ export class Queue extends EventEmitter {
     }
 
     return data;
+  }
+
+  /**
+   * The redis key which holds the currently elected leader
+   */
+  leaderKey() {
+    return this.connection.key("resque_scheduler_leader_lock");
   }
 }

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -172,14 +172,8 @@ export class Scheduler extends EventEmitter {
     }
   }
 
-  private leaderKey() {
-    // TODO: Figure out if more work is needed
-    // return this.connection.key("resque_scheduler_master_lock");
-    return this.connection.key("resque_scheduler_leader_lock");
-  }
-
   private async tryForLeader() {
-    const leaderKey = this.leaderKey();
+    const leaderKey = this.queue.leaderKey();
     if (!this.connection || !this.connection.redis) {
       return;
     }
@@ -218,7 +212,7 @@ export class Scheduler extends EventEmitter {
       return false;
     }
 
-    const deleted = await this.connection.redis.del(this.leaderKey());
+    const deleted = await this.connection.redis.del(this.queue.leaderKey());
     this.leader = false;
     return deleted === 1 || deleted.toString() === "true";
   }


### PR DESCRIPTION
This PR provides `await queue.leader(): string` to see who the currently elected leader is.