### PR TITLE
Add ability to delete jobs in a queue by function alone without args

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can read the API docs for Node Resque @ [node-resque.actionherojs.com](https
 ## Version Notes
 
 - The version of redis required is >= 2.6.0 as we use lua scripting to create custom atomic operations
-- ‼️ Version 6+ of Node Resque uses TypeScript. We will still include JavaScript transpiled code in NPM releases, but they will be generated from the TypeScript source. Functinality between node-resque v5 and v6 should be the same.
+- ‼️ Version 6+ of Node Resque uses TypeScript. We will still include JavaScript transpiled code in NPM releases, but they will be generated from the TypeScript source. Functionality between node-resque v5 and v6 should be the same.
 - ‼️ Version 5+ of Node Resque uses async/await. There is no upgrade path from previous versions. Node v8.0.0+ is required.
 
 ## Usage

--- a/__tests__/core/queue.ts
+++ b/__tests__/core/queue.ts
@@ -211,7 +211,7 @@ describe("queue", () => {
       expect(timestamps.length).toBe(0);
     });
 
-    test("can deleted an enqued job", async () => {
+    test("can delete an enqueued job", async () => {
       await queue.enqueue(specHelper.queue, "someJob", [1, 2, 3]);
       const length = await queue.length(specHelper.queue);
       expect(length).toBe(1);
@@ -221,7 +221,29 @@ describe("queue", () => {
       expect(lengthAgain).toBe(0);
     });
 
-    test("can deleted a delayed job", async () => {
+    test("can delete all enqueued jobs of a particular function/class", async () => {
+      await queue.enqueue(specHelper.queue, "someJob1", [1, 2, 3]);
+      const length = await queue.length(specHelper.queue);
+      expect(length).toBe(1);
+
+      await queue.enqueue(specHelper.queue, "someJob1", [1, 2, 3]);
+      const lengthAgain = await queue.length(specHelper.queue);
+      expect(lengthAgain).toBe(2);
+
+      await queue.enqueue(specHelper.queue, "someJob2", [1, 2, 3]);
+      const lengthOnceAgain = await queue.length(specHelper.queue);
+      expect(lengthOnceAgain).toBe(3);
+
+      const countDeleted = await queue.delByFunction(
+        specHelper.queue,
+        "someJob1"
+      );
+      const lengthFinally = await queue.length(specHelper.queue);
+      expect(countDeleted).toBe(2);
+      expect(lengthFinally).toBe(1);
+    });
+
+    test("can delete a delayed job", async () => {
       await queue.enqueueAt(10000, specHelper.queue, "someJob", [1, 2, 3]);
       const timestamps = await queue.delDelayed(specHelper.queue, "someJob", [
         1,


### PR DESCRIPTION
Adds `await queue.delByFunction(queue, functionOrClassName)`