### PR TITLE
Adding some high level documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 **Distributed delayed jobs in nodejs**. Resque is a background job system backed by [Redis](http://redis.io) (version 2.6.0 and up required). It includes priority queues, plugins, locking, delayed jobs, and more! This project is a very opinionated but API-compatible with [Resque](https://github.com/resque/resque) and [Sidekiq](http://sidekiq.org/) ([caveats](https://github.com/actionhero/node-resque/issues/311)). We also implement some of the popular Resque plugins, including [resque-scheduler](https://github.com/resque/resque-scheduler) and [resque-retry](https://github.com/lantins/resque-retry)
 
-The full API documentation for this package is automatically generated from the `master` via [typedoc](https://typedoc.org) branch and published to https://node-resque.actionherojs.com/
+The full API documentation for this package is automatically generated from the `main` via [typedoc](https://typedoc.org) branch and published to https://node-resque.actionherojs.com/
 
 [![Nodei stats](https://nodei.co/npm/node-resque.png?downloads=true)](https://npmjs.org/package/node-resque)
 
 [![CircleCI](https://circleci.com/gh/actionhero/node-resque.svg?style=svg)](https://circleci.com/gh/actionhero/node-resque)
 
+## The Resque Factory (How It Works)
+### Overview
+Resque is a queue based task processing system that can be thought of as a "Kanban" style factory. Workers in this factory can each only work one Job at a time. They pull Jobs from Queues and work them to completion (or failure). Each Job has two parts: instructions how how to complete the job (the `perform` function), and any inputs necessary to complete the Job.
+
+### Queues
+In our factory example, Queues are analogous to conveyor belts. Jobs are placed on the belts (Queues) and are held in order waiting for a Worker to pick them up. There are two "special" Queues: the Delayed Job Queue, and the Failed Job Queue. The Delayed Job Queue contains Job definitions that are intended to be worked at or in a specified time. The Failed Job Queue is where Workers place any Jobs that have failed during execution.
+
+### Workers
+Our Workers are the heart of the factory. Each Worker is assigned one or more Queues to check for work. After taking a Job from a Queue the Worker attempts to complete the Job. If successful, they go back to check out more work from the Queues. However, if there is a failure, the Worker records the job and its inputs in the Failed Jobs Queue before going back for more work.
+
+### Scheduler
+The Scheduler can be thought of as a specialized type of Worker. Unlike other Workers, the Scheduler does not execute any Jobs, instead it manages the Delayed Job Queue. As Job definitions are added to the Delayed Job Queue they must specify when they can become available for execution. The Scheduler constantly checks to see if any Delayed Jobs are ready to execute. When a Delayed Job becomes ready for execution the Scheduler places a new instance of that Job in its defined Queue.  
 ## API Docs
 
 You can read the API docs for Node Resque @ [node-resque.actionherojs.com](https://node-resque.actionherojs.com). These are generated automatically from the master branch via [TypeDoc](https://typedoc.org/)
@@ -210,6 +222,7 @@ There are 3 main classes in `node-resque`: Queue, Worker, and Scheduler
   - There's a special class called `multiWorker` in Node Resque which will run many workers at once for you (see below).
 - **Scheduler**: The scheduler can be thought of as the coordinator for Node Resque. It is primarily in charge of checking when jobs told to run later (with `queue.enqueueIn` or `queue.enqueueAt`) should be processed, but it performs some other jobs like checking for 'stuck' workers and general cluster cleanup.
   - You can (and should) run many instances of the scheduler class at once, but only one will be elected to be the 'leader', and actually do work.
+  - The 'delay' defined on a scheduled job does not specify when the job should be run, but rather when the job should be enqueued. This means that `node-resque` can not guarantee when a job is going to be executed, only when it will become _available_ for execution (added to a Queue).
 
 ## Configuration Options:
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,23 @@ The full API documentation for this package is automatically generated from the 
 [![CircleCI](https://circleci.com/gh/actionhero/node-resque.svg?style=svg)](https://circleci.com/gh/actionhero/node-resque)
 
 ## The Resque Factory (How It Works)
+
 ### Overview
+
 Resque is a queue based task processing system that can be thought of as a "Kanban" style factory. Workers in this factory can each only work one Job at a time. They pull Jobs from Queues and work them to completion (or failure). Each Job has two parts: instructions on how to complete the job (the `perform` function), and any inputs necessary to complete the Job.
 
 ### Queues
+
 In our factory example, Queues are analogous to conveyor belts. Jobs are placed on the belts (Queues) and are held in order waiting for a Worker to pick them up. There are two "special" Queues: the Delayed Job Queue, and the Failed Job Queue. The Delayed Job Queue contains Job definitions that are intended to be worked at or in a specified time. The Failed Job Queue is where Workers place any Jobs that have failed during execution.
 
 ### Workers
+
 Our Workers are the heart of the factory. Each Worker is assigned one or more Queues to check for work. After taking a Job from a Queue the Worker attempts to complete the Job. If successful, they go back to check out more work from the Queues. However, if there is a failure, the Worker records the job and its inputs in the Failed Jobs Queue before going back for more work.
 
 ### Scheduler
-The Scheduler can be thought of as a specialized type of Worker. Unlike other Workers, the Scheduler does not execute any Jobs, instead it manages the Delayed Job Queue. As Job definitions are added to the Delayed Job Queue they must specify when they can become available for execution. The Scheduler constantly checks to see if any Delayed Jobs are ready to execute. When a Delayed Job becomes ready for execution the Scheduler places a new instance of that Job in its defined Queue. 
- 
+
+The Scheduler can be thought of as a specialized type of Worker. Unlike other Workers, the Scheduler does not execute any Jobs, instead it manages the Delayed Job Queue. As Job definitions are added to the Delayed Job Queue they must specify when they can become available for execution. The Scheduler constantly checks to see if any Delayed Jobs are ready to execute. When a Delayed Job becomes ready for execution the Scheduler places a new instance of that Job in its defined Queue.
+
 ## API Docs
 
 You can read the API docs for Node Resque @ [node-resque.actionherojs.com](https://node-resque.actionherojs.com). These are generated automatically from the master branch via [TypeDoc](https://typedoc.org/)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Resque is a queue based task processing system that can be thought of as a "Kanb
 
 ### Queues
 
-In our factory example, Queues are analogous to conveyor belts. Jobs are placed on the belts (Queues) and are held in order waiting for a Worker to pick them up. There are two "special" Queues: the Delayed Job Queue, and the Failed Job Queue. The Delayed Job Queue contains Job definitions that are intended to be worked at or in a specified time. The Failed Job Queue is where Workers place any Jobs that have failed during execution.
+In our factory example, Queues are analogous to conveyor belts. Jobs are placed on the belts (Queues) and are held in order waiting for a Worker to pick them up. There are three types of Queues: regular work Queues, Delayed Job Queues, and the Failed Job Queue. The Delayed Job Queues contains Job definitions that are intended to be worked at or in a specified time. The Failed Job Queue is where Workers place any Jobs that have failed during execution.
 
 ### Workers
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The full API documentation for this package is automatically generated from the 
 
 ## The Resque Factory (How It Works)
 ### Overview
-Resque is a queue based task processing system that can be thought of as a "Kanban" style factory. Workers in this factory can each only work one Job at a time. They pull Jobs from Queues and work them to completion (or failure). Each Job has two parts: instructions how how to complete the job (the `perform` function), and any inputs necessary to complete the Job.
+Resque is a queue based task processing system that can be thought of as a "Kanban" style factory. Workers in this factory can each only work one Job at a time. They pull Jobs from Queues and work them to completion (or failure). Each Job has two parts: instructions on how to complete the job (the `perform` function), and any inputs necessary to complete the Job.
 
 ### Queues
 In our factory example, Queues are analogous to conveyor belts. Jobs are placed on the belts (Queues) and are held in order waiting for a Worker to pick them up. There are two "special" Queues: the Delayed Job Queue, and the Failed Job Queue. The Delayed Job Queue contains Job definitions that are intended to be worked at or in a specified time. The Failed Job Queue is where Workers place any Jobs that have failed during execution.
@@ -19,7 +19,8 @@ In our factory example, Queues are analogous to conveyor belts. Jobs are placed 
 Our Workers are the heart of the factory. Each Worker is assigned one or more Queues to check for work. After taking a Job from a Queue the Worker attempts to complete the Job. If successful, they go back to check out more work from the Queues. However, if there is a failure, the Worker records the job and its inputs in the Failed Jobs Queue before going back for more work.
 
 ### Scheduler
-The Scheduler can be thought of as a specialized type of Worker. Unlike other Workers, the Scheduler does not execute any Jobs, instead it manages the Delayed Job Queue. As Job definitions are added to the Delayed Job Queue they must specify when they can become available for execution. The Scheduler constantly checks to see if any Delayed Jobs are ready to execute. When a Delayed Job becomes ready for execution the Scheduler places a new instance of that Job in its defined Queue.  
+The Scheduler can be thought of as a specialized type of Worker. Unlike other Workers, the Scheduler does not execute any Jobs, instead it manages the Delayed Job Queue. As Job definitions are added to the Delayed Job Queue they must specify when they can become available for execution. The Scheduler constantly checks to see if any Delayed Jobs are ready to execute. When a Delayed Job becomes ready for execution the Scheduler places a new instance of that Job in its defined Queue. 
+ 
 ## API Docs
 
 You can read the API docs for Node Resque @ [node-resque.actionherojs.com](https://node-resque.actionherojs.com). These are generated automatically from the master branch via [TypeDoc](https://typedoc.org/)


### PR DESCRIPTION
Due to some discussion on the Actionhero Slack, it seems that some additional explanatory documentation would be useful for reducing confusion about how Jobs are handled by the Scheduler.