### PR TITLE
Fix Multiworker error event types

### DIFF
--- a/src/core/multiWorker.ts
+++ b/src/core/multiWorker.ts
@@ -54,17 +54,17 @@ export declare interface MultiWorker {
       workerId: number,
       queue: string,
       job: Job<any> | JobEmit,
-      failure: any,
+      failure: Error,
       duration: number
     ) => void
   ): this;
   on(
     event: "error",
     cb: (
+      error: Error,
       workerId: number,
       queue: string,
-      job: Job<any> | JobEmit,
-      error: any
+      job: Job<any> | JobEmit
     ) => void
   ): this;
   on(event: "pause", cb: (workerId: number) => void): this;

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -48,7 +48,7 @@ export declare interface Worker {
   ): this;
   on(
     event: "failure",
-    cb: (queue: string, job: JobEmit, failure: any, duration: number) => void
+    cb: (queue: string, job: JobEmit, failure: Error, duration: number) => void
   ): this;
   on(
     event: "error",


### PR DESCRIPTION
Fixes the type of the MultiWorker event for `on('error')` - the Error object comes first