### PR TITLE
Do not use Atomic Lua script to prepare worker jobs when using Redis Cluster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "node-resque",
       "version": "9.1.2",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -366,7 +366,6 @@ export class Queue extends EventEmitter {
       return data;
     }
 
-    // const values = await this.connection.redis.mget(keys)
     for (const i in keys) {
       let value = await this.connection.redis.get(keys[i]);
       values.push(value);


### PR DESCRIPTION
We cannot use the atomic Lua script if we are using redis cluster - the shard storing the queue and worker may not be the same

An alternative approach would be to use Redis Hash keys, but then every key would start with `{resque}:` rather than `resque:`, breaking compatibility with other implementations of resque. 