### PR TITLE
Adds delay enqueue hooks

### DIFF
--- a/__tests__/core/pluginRunner.ts
+++ b/__tests__/core/pluginRunner.ts
@@ -1,0 +1,261 @@
+import specHelper from "../utils/specHelper";
+import { Queue, Worker, Job } from "../../src";
+import { HooksPlugin } from "../utils/custom-plugin";
+import { RunPlugins } from "../../src/core/pluginRunner";
+
+describe("plugin runner", () => {
+  const jobs = {
+    //@ts-ignore
+    myJob: {
+      plugins: [HooksPlugin],
+      perform: async () => {
+        throw new Error("should not get here");
+      },
+    } as Job<any>,
+  };
+
+  describe("queue hooks", () => {
+    const queue = new Queue(
+      {
+        connection: specHelper.cleanConnectionDetails(),
+        queue: specHelper.queue,
+      },
+      jobs
+    );
+
+    describe("beforeEnqueue", () => {
+      test("it will not permit adding properties to args", async () => {
+        HooksPlugin.prototype.beforeEnqueue = async function () {
+          this.args.push(3);
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "beforeEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [1, 2]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+
+      test("it will not permit adding properties to nested args", async () => {
+        HooksPlugin.prototype.beforeEnqueue = async function () {
+          this.args[0].a.b = true;
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "beforeEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [{ a: {} }]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+    });
+
+    describe("afterEnqueue", () => {
+      test("it will not permit adding properties to args", async () => {
+        HooksPlugin.prototype.afterEnqueue = async function () {
+          this.args.push(3);
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "afterEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [1, 2]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+
+      test("it will not permit adding properties to nested args", async () => {
+        HooksPlugin.prototype.afterEnqueue = async function () {
+          this.args[0].a.b = true;
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "afterEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [{ a: {} }]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+    });
+
+    describe("beforeDelayEnqueue", () => {
+      test("it will not permit adding properties to args", async () => {
+        HooksPlugin.prototype.beforeDelayEnqueue = async function () {
+          this.args.push(3);
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "beforeDelayEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [1, 2]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+
+      test("it will not permit adding properties to nested args", async () => {
+        HooksPlugin.prototype.beforeDelayEnqueue = async function () {
+          this.args[0].a.b = true;
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "beforeDelayEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [{ a: {} }]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+    });
+
+    describe("afterDelayEnqueue", () => {
+      test("it will not permit adding properties to args", async () => {
+        HooksPlugin.prototype.afterDelayEnqueue = async function () {
+          this.args.push(3);
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "afterDelayEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [1, 2]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+
+      test("it will not permit adding properties to nested args", async () => {
+        HooksPlugin.prototype.afterDelayEnqueue = async function () {
+          this.args[0].a.b = true;
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            queue,
+            "afterDelayEnqueue",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [{ a: {} }]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+    });
+  });
+
+  describe("worker hooks", () => {
+    const worker = new Worker(
+      { connection: specHelper.connectionDetails, queues: [specHelper.queue] },
+      {}
+    );
+
+    describe("beforePerform", () => {
+      test("it will not permit adding properties to args", async () => {
+        HooksPlugin.prototype.beforePerform = async function () {
+          this.args.push(3);
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            worker,
+            "beforePerform",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [1, 2]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+
+      test("it will not permit adding properties to nested args", async () => {
+        HooksPlugin.prototype.beforePerform = async function () {
+          this.args[0].a.b = true;
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            worker,
+            "beforePerform",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [{ a: {} }]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+    });
+
+    describe("afterPerform", () => {
+      test("it will not permit adding properties to args", async () => {
+        HooksPlugin.prototype.afterPerform = async function () {
+          this.args.push(3);
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            worker,
+            "afterPerform",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [1, 2]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+
+      test("it will not permit adding properties to nested args", async () => {
+        HooksPlugin.prototype.afterPerform = async function () {
+          this.args[0].a.b = true;
+          return true;
+        };
+
+        await expect(
+          RunPlugins(
+            worker,
+            "afterPerform",
+            "myJob",
+            specHelper.queue,
+            jobs.myJob,
+            [{ a: {} }]
+          )
+        ).rejects.toThrow(TypeError);
+      });
+    });
+  });
+});

--- a/__tests__/integration/functions.ts
+++ b/__tests__/integration/functions.ts
@@ -1,0 +1,36 @@
+import { LockArgs, DeepMerge } from "../../src/utils/functions";
+
+describe("utility helpers", () => {
+  describe("LockArgs", () => {
+    test("should return an array", () => {
+      expect(LockArgs({ a: 1 })).toEqual([{ a: 1 }]);
+    });
+
+    test("should return a sealed array", () => {
+      const locked = LockArgs({ a: 1 });
+      expect(Object.isSealed(locked)).toEqual(true);
+    });
+
+    test("should seal nested property values", () => {
+      const locked = LockArgs({ a: [{ b: true }] });
+      expect(Object.isSealed(locked[0].a[0].b)).toEqual(true);
+    });
+  });
+
+  describe("DeepMerge", () => {
+    test("should override existing properties on target object", () => {
+      const target = [{ a: 1, b: 2 }];
+      const merge = [{ a: 8, c: 3 }];
+      expect(DeepMerge(target, merge)).toEqual([{ a: 8, b: 2, c: 3 }]);
+    });
+
+    test("should override existing nested properties on target object", () => {
+      const target = [{ a: [{ b: 1 }] }];
+      const merge = [{ a: [{ b: 2 }] }, "new property"];
+      expect(DeepMerge(target, merge)).toEqual([
+        { a: [{ b: 2 }] },
+        "new property",
+      ]);
+    });
+  });
+});

--- a/__tests__/plugins/queueLock.ts
+++ b/__tests__/plugins/queueLock.ts
@@ -7,7 +7,15 @@ class NeverRunPlugin extends Plugin {
     return true;
   }
 
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
   async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
     return true;
   }
 

--- a/__tests__/utils/custom-plugin.ts
+++ b/__tests__/utils/custom-plugin.ts
@@ -6,7 +6,15 @@ export class CustomPlugin extends Plugin {
     return false;
   }
 
+  async beforeDelayEnqueue() {
+    return false;
+  }
+
   async afterEnqueue() {
+    return false;
+  }
+
+  async afterDelayEnqueue() {
     return false;
   }
 
@@ -16,5 +24,31 @@ export class CustomPlugin extends Plugin {
 
   async afterPerform() {
     return false;
+  }
+}
+
+export class HooksPlugin extends Plugin {
+  async beforeEnqueue() {
+    return true;
+  }
+
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
+  async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
+    return true;
+  }
+
+  async beforePerform() {
+    return true;
+  }
+
+  async afterPerform() {
+    return true;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "9.1.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "deepmerge": "^4.2.2",
         "ioredis": "^4.27.6"
       },
       "devDependencies": {
@@ -1666,7 +1667,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6189,8 +6189,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
+    "deepmerge": "^4.2.2",
     "ioredis": "^4.27.6"
   },
   "devDependencies": {

--- a/src/plugins/DelayQueueLock.ts
+++ b/src/plugins/DelayQueueLock.ts
@@ -16,7 +16,15 @@ export class DelayQueueLock extends Plugin {
     }
   }
 
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
   async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
     return true;
   }
 

--- a/src/plugins/JobLock.ts
+++ b/src/plugins/JobLock.ts
@@ -6,7 +6,15 @@ export class JobLock extends Plugin {
     return true;
   }
 
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
   async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
     return true;
   }
 

--- a/src/plugins/Noop.ts
+++ b/src/plugins/Noop.ts
@@ -18,7 +18,15 @@ export class Noop extends Plugin {
     return true;
   }
 
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
   async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
     return true;
   }
 

--- a/src/plugins/QueueLock.ts
+++ b/src/plugins/QueueLock.ts
@@ -26,7 +26,15 @@ export class QueueLock extends Plugin {
     return true;
   }
 
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
   async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
     return true;
   }
 

--- a/src/plugins/Retry.ts
+++ b/src/plugins/Retry.ts
@@ -31,7 +31,15 @@ export class Retry extends Plugin {
     return true;
   }
 
+  async beforeDelayEnqueue() {
+    return true;
+  }
+
   async afterEnqueue() {
+    return true;
+  }
+
+  async afterDelayEnqueue() {
     return true;
   }
 

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -1,0 +1,58 @@
+import * as deepmerge from "deepmerge";
+const Merge = require("deepmerge");
+
+const combineMerge = (
+  target: Array<any>,
+  source: Array<any>,
+  options: deepmerge.Options
+) => {
+  source.forEach((item, index) => {
+    if (typeof target[index] === "undefined") {
+      target[index] = item;
+    } else if (options.isMergeableObject(item)) {
+      target[index] = Merge(target[index], item, options);
+    } else if (target.indexOf(item) === -1) {
+      target.push(item);
+    }
+  });
+  return target;
+};
+
+/**
+ * Deep merge everything from the incoming (source) array
+ * into the target array. If the target array is sealed
+ * any attempt to add/remove a property or value will
+ * raise a TypeError
+ */
+export function DeepMerge(target: Array<any>, source: Array<any>): Array<any> {
+  return Merge(target, source, { arrayMerge: combineMerge });
+}
+
+/**
+ * Deeply seals all objects within the input argument
+ * and returns the result as a sealed, flattened array
+ * for use as plugin or job args
+ */
+export function LockArgs<T>(
+  arg: T | T[] | { [key: string]: any },
+  arrayify: boolean = true
+): any {
+  if (arrayify) {
+    arg = [arg].flat() as T[];
+  }
+
+  if (Array.isArray(arg)) {
+    arg = arg.map((i: any) => LockArgs(i, false));
+  } else if (Object.prototype.toString.call(arg) === "[object Object]") {
+    arg = Object.keys(arg).reduce(
+      (obj: { [key: string]: any }, key: string): T => {
+        return Object.assign(obj, {
+          [key]: LockArgs((arg as { [key: string]: any })[key], false),
+        }) as T;
+      },
+      {}
+    ) as { [key: string]: any };
+  }
+
+  return Object.seal(arg);
+}


### PR DESCRIPTION
This attempts to address issues raised in #721 

Introduction of beforeDelayEnqueue/afterDelayEnqueue plugin hooks, which are the retry plugin equivalent of beforeEnqueue/afterEnqueue

There were still issues surrounding the frozen args object, making it impossible to manipulate arg data when entering the beforePerform hook unless workarounds like `JSON.parse(JSON.stringify(this.args))` were used. To that end, the use of `Object.freeze` was replaced with [Object.seal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal), and the reference to `this.args` from within a Plugin class was converted into a getter/setter that merges the value of reassigned args with the original args data, effectively preventing someone from adding/deleting a property from the args, but allowing them to modify properties that were in the original args. For example:

```
// Assume `this.args` is originally: [{ user: 'gid://User/1', flag: true, nested: { a: 1, b: 2 } }]
// ...
async beforeEnqueue(){ // Or any before/after hook
  this.args[0].flag = false // This works fine, the sealed `this.args` already contained the property `flag`
  this.args[0].newProp = "whatever" // Will throw a TypeError because `this.args` is a sealed object and `newProp` is new
  delete this.args[0].user // Will throw an error because `this.args` is a sealed object

  // Reassigning the whole args property
  this.args = [{ user: { name: 'Keanu' }, flag: false, nested: { c: 3 } }] // This will fail because the nested property `c` is new
  this.args = [{ user: { name: 'Keanu' }, flag: false, nested: { a: 88 } }] // This works, all properties are known already
}
```

I debated whether or not to surface the TypeError that's thrown when a sealed object is added to or removed from, but I felt that might cause confusion if you tried to assign a new property to args and it just never appeared. Having the TypeError bubble seems a bit better, so that's what it does. If you try to manipulate args in a way that's not permitted the error will be thrown and the job will fail, so you'd see that in the logs.

Sorry this took so long, @evantahler Holidays and such... Would love to get your feedback on this, I know the change to Object.freeze may seem a bit unexpected, but I'm hoping it will meet that middle ground goal of not breaking the issue raised in #99 while still permitting manipulation of args, at least within `beforePerform`. Perhaps I don't understand the ramifications of modifying args though.