### PR TITLE
Use pipelines to to make more transactional actions

### DIFF
--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -219,9 +219,7 @@ export class Scheduler extends EventEmitter {
       0,
       1
     );
-    if (items.length === 0) {
-      return;
-    }
+    if (items.length === 0) return;
     return items[0];
   }
 


### PR DESCRIPTION
Specifically, when removing a stuck worker (`queue.forceCleanWorker()`) it was possible to only do part of the cleanup if the redis server or the node process had a problem in the middle of the method.