### PR TITLE
Remove multiWorker internalError listener example

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,11 +629,6 @@ multiWorker.on("error", (workerId, queue, job, error) => {
 multiWorker.on("pause", (workerId) => {
   console.log("worker[" + workerId + "] paused");
 });
-
-// multiWorker emitters
-multiWorker.on("internalError", (error) => {
-  console.log(error);
-});
 multiWorker.on("multiWorkerAction", (verb, delay) => {
   console.log(
     "*** checked for worker status: " +

--- a/src/core/multiWorker.ts
+++ b/src/core/multiWorker.ts
@@ -271,7 +271,6 @@ export class MultiWorker extends EventEmitter {
       "failure",
       "error",
       "pause",
-      "internalError",
       "multiWorkerAction",
     ].forEach((e) => {
       worker.removeAllListeners(e);


### PR DESCRIPTION
Closes #767 

Removes the `internalError` listener example from the README, as well as trying to remove listener for it in the code as a listener is never added.