### PR TITLE
Fix transaction error handling

### DIFF
--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -185,7 +185,7 @@ export class Queue extends EventEmitter {
       .del(this.connection.key("queue", q))
       .srem(this.connection.key("queues"), q)
       .exec();
-    
+
     response.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
@@ -249,7 +249,7 @@ export class Queue extends EventEmitter {
     }
 
     const response = await pipeline.exec();
-    
+
     response.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
@@ -284,7 +284,7 @@ export class Queue extends EventEmitter {
     }
 
     const response = await pipeline.exec();
-    
+
     response.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
@@ -534,7 +534,7 @@ export class Queue extends EventEmitter {
     }
 
     const response = await pipeline.exec();
-    
+
     response.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -86,11 +86,17 @@ export class Queue extends EventEmitter {
     const toRun = await RunPlugins(this, "beforeEnqueue", func, q, job, args);
     if (toRun === false) return toRun;
 
-    await this.connection.redis
+    const response = await this.connection.redis
       .multi()
       .sadd(this.connection.key("queues"), q)
       .rpush(this.connection.key("queue", q), this.encode(q, func, args))
       .exec();
+
+    response.forEach((res) => {
+      if (res[0] !== null) {
+        throw res[0];
+      }
+    });
 
     await RunPlugins(this, "afterEnqueue", func, q, job, args);
     return toRun;
@@ -129,7 +135,7 @@ export class Queue extends EventEmitter {
       }
     }
 
-    await this.connection.redis
+    const response = await this.connection.redis
       .multi()
       .rpush(this.connection.key("delayed:" + rTimestamp), item)
       .sadd(this.connection.key("timestamps:" + item), "delayed:" + rTimestamp)
@@ -139,6 +145,12 @@ export class Queue extends EventEmitter {
         rTimestamp.toString(),
       )
       .exec();
+
+    response.forEach((res) => {
+      if (res[0] !== null) {
+        throw res[0];
+      }
+    });
   }
   /**
    * - In ms, the number of ms to delay before this job is able to start being worked on.
@@ -168,11 +180,17 @@ export class Queue extends EventEmitter {
    */
   async delQueue(q: string) {
     const { redis } = this.connection;
-    await redis
+    const response = await redis
       .multi()
       .del(this.connection.key("queue", q))
       .srem(this.connection.key("queues"), q)
       .exec();
+    
+    response.forEach((res) => {
+      if (res[0] !== null) {
+        throw res[0];
+      }
+    });
   }
 
   /**
@@ -230,7 +248,14 @@ export class Queue extends EventEmitter {
       }
     }
 
-    await pipeline.exec();
+    const response = await pipeline.exec();
+    
+    response.forEach((res) => {
+      if (res[0] !== null) {
+        throw res[0];
+      }
+    });
+
     return numJobsDeleted;
   }
 
@@ -258,7 +283,14 @@ export class Queue extends EventEmitter {
       }
     }
 
-    await pipeline.exec();
+    const response = await pipeline.exec();
+    
+    response.forEach((res) => {
+      if (res[0] !== null) {
+        throw res[0];
+      }
+    });
+
     return timestamps.map((t) => parseInt(t, 10));
   }
 
@@ -501,7 +533,13 @@ export class Queue extends EventEmitter {
       );
     }
 
-    await pipeline.exec();
+    const response = await pipeline.exec();
+    
+    response.forEach((res) => {
+      if (res[0] !== null) {
+        throw res[0];
+      }
+    });
 
     return errorPayload;
   }

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -254,11 +254,17 @@ export class Scheduler extends EventEmitter {
     await this.watchIfPossible(this.connection.key("delayed_queue_schedule"));
     const length = await this.connection.redis.llen(key);
     if (length === 0) {
-      await this.connection.redis
+      const response = await this.connection.redis
         .multi()
         .del(key)
         .zrem(this.connection.key("delayed_queue_schedule"), timestamp)
         .exec();
+
+      response.forEach((res) => {
+        if (res[0] !== null) {
+          throw res[0];
+        }
+      });
     }
     await this.unwatchIfPossible();
   }

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -409,13 +409,13 @@ export class Worker extends EventEmitter {
       .incr(this.connection.key("stat", "processed"))
       .incr(this.connection.key("stat", "processed", this.name))
       .exec();
-    
+
     response.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
     });
-    
+
     this.emit("success", this.queue, job, this.result, duration);
   }
 


### PR DESCRIPTION
Fix #970. When multiple operations are executed together as a transaction in `ioredis`, the return value takes the following form. 
```
const promise = redis.pipeline().set("foo", "bar").get("foo").exec();
promise.then((result) => {
  // result === [[null, 'OK'], [null, 'bar']]
});
```
Even if an error occurs in individual operations, it will not be propagated as an error for the entire transaction. To catch errors in each discrete operation, the value in the response is processed in this PR.