### PR TITLE
Failure of transaction with watch should be ignored.

### DIFF
--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -259,12 +259,13 @@ export class Scheduler extends EventEmitter {
         .del(key)
         .zrem(this.connection.key("delayed_queue_schedule"), timestamp)
         .exec();
-
-      response.forEach((res) => {
-        if (res[0] !== null) {
-          throw res[0];
-        }
-      });
+      if (response !== null) {
+        response.forEach((res) => {
+          if (res[0] !== null) {
+            throw res[0];
+          }
+        });
+      }
     }
     await this.unwatchIfPossible();
   }


### PR DESCRIPTION
The method `Scheduler.cleanupTimestamp` uses Optimistic locking by watch command, it's quite possible some watched keys changed during transaction (as a result, null is returned), it's OK, scheduler will start next polling, and the failed timestamp will be retried. 

ref: https://redis.io/docs/interact/transactions/#optimistic-locking-using-check-and-set

Closes https://github.com/actionhero/node-resque/issues/976#issuecomment-1675742090