### PR TITLE
Tighten ioredis range to ^5.10.1 to exclude broken 5.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "ioredis": "^5.9.1"
+        "ioredis": "^5.10.1"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "ioredis": "^5.9.1"
+    "ioredis": "^5.10.1"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

Closes #1287. Bumps the `ioredis` dependency range from `^5.9.1` to `^5.10.1` so that the broken `5.10.0` release can no longer be selected.

`ioredis@5.10.0` introduced a nominal-typing regression on `AbstractConnector` that causes TypeScript consumers (e.g. keryx) to fail when two ioredis copies end up coexisting in the dependency tree — one pulled via node-resque's loose range, one pinned tighter by the app. Narrowing our range to `^5.10.1` lets package managers dedupe and fixes the downstream type error without any code change in consumers.

## Test plan
- [ ] `npm test` passes locally against real Redis
- [ ] CI green on Node 20/24/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)