### PR TITLE
Fix build under TypeScript 6.0

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -12,7 +12,7 @@ export class Connection extends EventEmitter {
   options: ConnectionOptions;
   private eventListeners: EventListeners;
   connected: boolean;
-  redis: Redis | Cluster;
+  redis!: Redis | Cluster;
 
   constructor(options: ConnectionOptions = {}) {
     super();
@@ -49,13 +49,13 @@ export class Connection extends EventEmitter {
     if (this.options.redis) {
       this.redis = this.options.redis;
     } else {
-      const Pkg = require(this.options.pkg);
+      const Pkg = require(this.options.pkg!);
       if (
         typeof Pkg.createClient === "function" &&
         this.options.pkg !== "ioredis"
       ) {
         this.redis = Pkg.createClient(
-          this.options.port,
+          this.options.port!,
           this.options.host,
           this.options.options,
         );
@@ -80,7 +80,7 @@ export class Connection extends EventEmitter {
     });
 
     if (!this.options.redis && typeof this.redis.select === "function") {
-      await this.redis.select(this.options.database);
+      await this.redis.select(this.options.database!);
     }
 
     await connectionTestAndLoadLua();
@@ -109,7 +109,7 @@ export class Connection extends EventEmitter {
 
   async getKeys(
     match: string,
-    count: number = null,
+    count: number | null = null,
     keysAry: string[] = [],
     cursor = 0,
   ): Promise<string[]> {
@@ -139,6 +139,7 @@ export class Connection extends EventEmitter {
         "You must establish a connection to redis before running the getKeys command.",
       ),
     );
+    return keysAry;
   }
 
   end() {
@@ -160,7 +161,7 @@ export class Connection extends EventEmitter {
   }
 
   key(arg: any, arg2?: any, arg3?: any, arg4?: any): string {
-    let args;
+    let args: any[];
     args = arguments.length >= 1 ? [].slice.call(arguments, 0) : [];
     if (Array.isArray(this.options.namespace)) {
       args.unshift(...this.options.namespace);

--- a/src/core/multiWorker.ts
+++ b/src/core/multiWorker.ts
@@ -17,7 +17,7 @@ export declare interface MultiWorker {
   eventLoopDelay: number;
   eventLoopCheckCounter: number;
   stopInProcess: boolean;
-  checkTimer: NodeJS.Timeout;
+  checkTimer: NodeJS.Timeout | null;
 
   on(event: "start" | "end", cb: (workerId: number) => void): this;
   on(
@@ -82,6 +82,7 @@ export class MultiWorker extends EventEmitter {
     options.maxEventLoopDelay = options.maxEventLoopDelay ?? 10;
 
     if (
+      options.connection &&
       options.connection.redis &&
       typeof options.connection.redis.setMaxListeners === "function"
     ) {
@@ -95,7 +96,7 @@ export class MultiWorker extends EventEmitter {
     this.jobs = jobs;
     this.running = false;
     this.working = false;
-    this.name = this.options.name;
+    this.name = this.options.name!;
     this.eventLoopBlocked = true;
     this.eventLoopDelay = Infinity;
     this.eventLoopCheckCounter = 0;
@@ -107,8 +108,8 @@ export class MultiWorker extends EventEmitter {
 
   private PollEventLoopDelay() {
     EventLoopDelay(
-      this.options.maxEventLoopDelay,
-      this.options.checkTimeout,
+      this.options.maxEventLoopDelay!,
+      this.options.checkTimeout!,
       (blocked: boolean, ms: number) => {
         this.eventLoopBlocked = blocked;
         this.eventLoopDelay = ms;
@@ -191,7 +192,7 @@ export class MultiWorker extends EventEmitter {
       verb = "x";
     } else if (
       this.eventLoopBlocked &&
-      this.workers.length > this.options.minTaskProcessors
+      this.workers.length > this.options.minTaskProcessors!
     ) {
       verb = "-";
     } else if (
@@ -201,18 +202,18 @@ export class MultiWorker extends EventEmitter {
       verb = "x";
     } else if (
       !this.eventLoopBlocked &&
-      this.workers.length < this.options.minTaskProcessors
+      this.workers.length < this.options.minTaskProcessors!
     ) {
       verb = "+";
     } else if (
       !this.eventLoopBlocked &&
-      this.workers.length < this.options.maxTaskProcessors &&
+      this.workers.length < this.options.maxTaskProcessors! &&
       (this.workers.length === 0 || workingCount / this.workers.length > 0.5)
     ) {
       verb = "+";
     } else if (
       !this.eventLoopBlocked &&
-      this.workers.length > this.options.minTaskProcessors &&
+      this.workers.length > this.options.minTaskProcessors! &&
       workingCount / this.workers.length < 0.5
     ) {
       verb = "-";
@@ -226,6 +227,7 @@ export class MultiWorker extends EventEmitter {
 
     if (verb === "-") {
       worker = this.workers.pop();
+      if (!worker) return { verb, eventLoopDelay: this.eventLoopDelay };
       await worker.end();
       await this.cleanupWorker(worker);
       return { verb, eventLoopDelay: this.eventLoopDelay };
@@ -256,6 +258,8 @@ export class MultiWorker extends EventEmitter {
       await this.startWorker();
       return { verb, eventLoopDelay: this.eventLoopDelay };
     }
+
+    return { verb, eventLoopDelay: this.eventLoopDelay };
   }
 
   private async cleanupWorker(worker: Worker) {
@@ -278,7 +282,7 @@ export class MultiWorker extends EventEmitter {
   }
 
   private async checkWrapper() {
-    clearTimeout(this.checkTimer);
+    if (this.checkTimer) clearTimeout(this.checkTimer);
     const { verb, eventLoopDelay } = await this.checkWorkers();
     this.emit("multiWorkerAction", verb, eventLoopDelay);
     this.checkTimer = setTimeout(() => {
@@ -306,7 +310,7 @@ export class MultiWorker extends EventEmitter {
       this.working === false &&
       !this.stopInProcess
     ) {
-      clearTimeout(this.checkTimer);
+      if (this.checkTimer) clearTimeout(this.checkTimer);
       return;
     }
 

--- a/src/core/pluginRunner.ts
+++ b/src/core/pluginRunner.ts
@@ -58,8 +58,10 @@ export async function RunPlugin(
   if (typeof PluginReference === "function") {
     // @ts-ignore
     pluginName = new PluginReference(self, func, queue, job, args, {}).name;
-  } else if (typeof pluginName === "function") {
-    pluginName = pluginName["name"];
+  } else if (typeof PluginReference === "string") {
+    pluginName = PluginReference;
+  } else {
+    throw new Error("Plugin must be the constructor name or an object");
   }
 
   let pluginOptions = null;

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -92,7 +92,7 @@ export class Queue extends EventEmitter {
       .rpush(this.connection.key("queue", q), this.encode(q, func, args))
       .exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -146,7 +146,7 @@ export class Queue extends EventEmitter {
       )
       .exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -188,7 +188,7 @@ export class Queue extends EventEmitter {
       .srem(this.connection.key("queues"), q)
       .exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -252,7 +252,7 @@ export class Queue extends EventEmitter {
 
     const response = await pipeline.exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -287,7 +287,7 @@ export class Queue extends EventEmitter {
 
     const response = await pipeline.exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -387,9 +387,9 @@ export class Queue extends EventEmitter {
    */
   async locks() {
     let keys: Array<string> = [];
-    const data: { [key: string]: string } = {};
+    const data: { [key: string]: string | null } = {};
     let _keys: Array<string>;
-    let values = [];
+    let values: Array<string | null> = [];
 
     _keys = await this.connection.getKeys(this.connection.key("lock:*"));
     keys = keys.concat(_keys);
@@ -429,7 +429,7 @@ export class Queue extends EventEmitter {
    * - returns a hash of the form: `{ 'host:pid': 'queue1, queue2', 'host:pid': 'queue1, queue2' }`
    */
   async workers() {
-    const workers: { [key: string]: string } = {};
+    const workers: { [key: string]: string | null } = {};
 
     const results = await this.connection.redis.smembers(
       this.connection.key("workers"),
@@ -476,7 +476,7 @@ export class Queue extends EventEmitter {
       const w = Object.keys(workers)[i];
       //@ts-ignore
       results[w] = "started";
-      let data = await this.workingOn(w, workers[w]);
+      let data = await this.workingOn(w, workers[w] ?? "");
       if (data) {
         let parsedData = JSON.parse(data) as ParsedWorkerPayload;
         results[parsedData.worker] = parsedData;
@@ -487,7 +487,7 @@ export class Queue extends EventEmitter {
   }
 
   async forceCleanWorker(workerName: string) {
-    let errorPayload: ErrorPayload;
+    let errorPayload: ErrorPayload | undefined;
 
     const workers = await this.workers();
     const queues = workers[workerName];
@@ -537,7 +537,7 @@ export class Queue extends EventEmitter {
 
     const response = await pipeline.exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -67,7 +67,7 @@ export class Scheduler extends EventEmitter {
     options.retryStuckJobs = options.retryStuckJobs ?? false;
 
     this.options = options;
-    this.name = this.options.name;
+    this.name = this.options.name!;
     this.leader = false;
     this.running = false;
     this.processing = false;
@@ -122,7 +122,7 @@ export class Scheduler extends EventEmitter {
         setTimeout(async () => {
           await this.end();
           resolve(null);
-        }, this.options.timeout / 2);
+        }, this.options.timeout! / 2);
       });
     }
   }
@@ -173,9 +173,9 @@ export class Scheduler extends EventEmitter {
     try {
       const lockedByMe = await this.connection.redis.set(
         leaderKey,
-        this.options.name,
+        this.options.name!,
         "EX",
-        this.options.leaderLockTimeout,
+        this.options.leaderLockTimeout!,
         "NX",
       );
 
@@ -187,7 +187,7 @@ export class Scheduler extends EventEmitter {
       if (currentLeaderName === this.options.name) {
         await this.connection.redis.expire(
           leaderKey,
-          this.options.leaderLockTimeout,
+          this.options.leaderLockTimeout!,
         );
         return true;
       }
@@ -241,6 +241,7 @@ export class Scheduler extends EventEmitter {
   private async nextItemForTimestamp(timestamp: number) {
     const key = this.connection.key("delayed:" + timestamp);
     const job = await this.connection.redis.lpop(key);
+    if (!job) return null;
     await this.connection.redis.srem(
       this.connection.key("timestamps:" + job),
       "delayed:" + timestamp,
@@ -290,7 +291,8 @@ export class Scheduler extends EventEmitter {
     );
     const payloads: Array<Payload> = await Promise.all(
       keys.map(async (k) => {
-        return JSON.parse(await this.connection.redis.get(k));
+        const raw = await this.connection.redis.get(k);
+        return raw ? JSON.parse(raw) : null;
       }),
     );
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -21,17 +21,17 @@ export declare interface Worker {
   started: boolean;
   name: string;
   queues: Array<string> | string;
-  queue: string;
+  queue: string | null;
   originalQueue: string | null;
   error: Error | null;
   result: any;
   ready: boolean;
   running: boolean;
   working: boolean;
-  pollTimer: NodeJS.Timeout;
-  endTimer: NodeJS.Timeout;
-  pingTimer: NodeJS.Timeout;
-  job: ParsedJob;
+  pollTimer: NodeJS.Timeout | null;
+  endTimer: NodeJS.Timeout | null;
+  pingTimer: NodeJS.Timeout | null;
+  job: ParsedJob | null;
   connection: Connection;
   queueObject: Queue;
   id: number;
@@ -116,8 +116,8 @@ export class Worker extends EventEmitter {
 
     this.options = options;
     this.jobs = prepareJobs(jobs);
-    this.name = this.options.name;
-    this.queues = this.options.queues;
+    this.name = this.options.name!;
+    this.queues = this.options.queues!;
     this.queue = null;
     this.originalQueue = null;
     this.error = null;
@@ -176,9 +176,9 @@ export class Worker extends EventEmitter {
       return this.end();
     }
 
-    clearTimeout(this.pollTimer);
-    clearTimeout(this.endTimer);
-    clearInterval(this.pingTimer);
+    if (this.pollTimer) clearTimeout(this.pollTimer);
+    if (this.endTimer) clearTimeout(this.endTimer);
+    if (this.pingTimer) clearInterval(this.pingTimer);
 
     if (
       this.connection &&
@@ -193,10 +193,10 @@ export class Worker extends EventEmitter {
     this.emit("end", new Date());
   }
 
-  private async poll(nQueue = 0): Promise<ParsedJob> {
+  private async poll(nQueue = 0): Promise<ParsedJob | null | undefined> {
     if (!this.running) return;
 
-    this.queue = this.queues[nQueue];
+    this.queue = this.queues[nQueue] ?? null;
     this.emit("poll", this.queue);
 
     if (this.queue === null || this.queue === undefined) {
@@ -264,7 +264,7 @@ export class Worker extends EventEmitter {
         this,
         "beforePerform",
         job.class,
-        this.queue,
+        this.queue!,
         this.jobs[job.class],
         job.args,
       );
@@ -289,26 +289,26 @@ export class Worker extends EventEmitter {
         this,
         "afterPerform",
         job.class,
-        this.queue,
+        this.queue!,
         this.jobs[job.class],
         job.args,
       );
       return this.completeJob(true, startedAt);
     } catch (error) {
-      this.error = error;
+      this.error = error as Error;
       if (!triedAfterPerform) {
         try {
           await RunPlugins(
             this,
             "afterPerform",
             job.class,
-            this.queue,
+            this.queue!,
             this.jobs[job.class],
             job.args,
           );
         } catch (error) {
           if (error && !this.error) {
-            this.error = error;
+            this.error = error as Error;
           }
         }
       }
@@ -364,20 +364,20 @@ export class Worker extends EventEmitter {
       );
       return this.result;
     } catch (error) {
-      this.error = error;
+      this.error = error as Error;
       if (!triedAfterPerform) {
         try {
           await RunPlugins(
             this,
             "afterPerform",
             func,
-            this.queue,
+            this.queue!,
             this.jobs[func],
             args,
           );
         } catch (error) {
           if (error && !this.error) {
-            this.error = error;
+            this.error = error as Error;
           }
         }
       }
@@ -391,7 +391,7 @@ export class Worker extends EventEmitter {
     if (this.error) {
       await this.fail(this.error, duration);
     } else if (toRespond) {
-      await this.succeed(this.job, duration);
+      await this.succeed(this.job!, duration);
     }
 
     this.working = false;
@@ -412,7 +412,7 @@ export class Worker extends EventEmitter {
       .incr(this.connection.key("stat", "processed", this.name))
       .exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -428,11 +428,11 @@ export class Worker extends EventEmitter {
       .incr(this.connection.key("stat", "failed", this.name))
       .rpush(
         this.connection.key("failed"),
-        JSON.stringify(this.failurePayload(err, this.job)),
+        JSON.stringify(this.failurePayload(err, this.job!)),
       )
       .exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }
@@ -452,7 +452,7 @@ export class Worker extends EventEmitter {
   }
 
   private async getJob() {
-    let currentJob: ParsedJob;
+    let currentJob: ParsedJob | undefined;
     const queueKey = this.connection.key("queue", this.queue);
     const workerKey = this.connection.key(
       "worker",
@@ -460,7 +460,7 @@ export class Worker extends EventEmitter {
       this.stringQueues(),
     );
 
-    let encodedJob: string;
+    let encodedJob: string | null;
 
     if (
       // We cannot use the atomic Lua script if we are using redis cluster - the shard storing the queue and worker may not be the same
@@ -538,7 +538,7 @@ export class Worker extends EventEmitter {
       .del(this.connection.key("stat", "processed", name))
       .exec();
 
-    response.forEach((res) => {
+    response?.forEach((res) => {
       if (res[0] !== null) {
         throw res[0];
       }

--- a/src/plugins/JobLock.ts
+++ b/src/plugins/JobLock.ts
@@ -26,7 +26,7 @@ export class JobLock extends Plugin {
       return true;
     } else {
       const options = this.job.pluginOptions;
-      const toReEnqueue = options.JobLock
+      const toReEnqueue = options?.JobLock
         ? options.JobLock.reEnqueue !== null &&
           options.JobLock.reEnqueue !== undefined
           ? options.JobLock.reEnqueue

--- a/src/plugins/QueueLock.ts
+++ b/src/plugins/QueueLock.ts
@@ -16,7 +16,7 @@ export class QueueLock extends Plugin {
     }
 
     const redisTimeout = await this.queueObject.connection.redis.get(key);
-    const redisTimeoutInt = parseInt(redisTimeout);
+    const redisTimeoutInt = redisTimeout ? parseInt(redisTimeout) : 0;
     if (now <= redisTimeoutInt) {
       return false;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "./src",
     "allowJs": true,
     "module": "commonjs",
     "target": "es2018",
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strict": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Summary

`npm run build` was broken after the TypeScript 5.9 → 6.0 bump (#1285). TS 6.0 now requires `rootDir` to be explicit and enables stricter defaults that surfaced a pile of latent strict-mode violations.

- Pinned `strict: true` (and added `rootDir: "./src"`) in `tsconfig.json` rather than relaxing flags
- Fixed each strict-mode violation in code: nullable timers/job/queue on the `Worker` interface, non-null assertions on options with constructor defaults, null guards on `redis.exec()` / `lpop` / `get` returns, optional chaining on `pluginOptions`, etc.
- Fixed a real bug in `pluginRunner.RunPlugin`: the `else if (typeof pluginName === "function")` branch was checking the unassigned local instead of `PluginReference`, so `pluginName` was left `undefined` whenever a plugin was passed as a string. Now correctly assigns `pluginName = PluginReference` in that case.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes against a local Redis
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)